### PR TITLE
Add Microsoft Azure to Snowpark supported cloud providers

### DIFF
--- a/site/sfguides/src/getting_started_with_snowpark/getting_started_with_snowpark.md
+++ b/site/sfguides/src/getting_started_with_snowpark/getting_started_with_snowpark.md
@@ -23,7 +23,7 @@ Snowpark is a [preview feature](https://docs.snowflake.com/en/release-notes/prev
 - Familiarity with Scala
 
 ### What You’ll Need
-- A [Snowflake](https://www.snowflake.com/) account hosted on Amazon Web Services (AWS)
+- A [Snowflake](https://www.snowflake.com/) account hosted on Amazon Web Services (AWS) or Microsoft Azure. 
 - [git](https://git-scm.com/downloads)
 - [SBT](https://www.scala-sbt.org/)
 


### PR DESCRIPTION
Add Microsoft Azure as a supported cloud platform for Snowpark (Oct 2021 release)