### PR TITLE
Don't ignore /site/package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ debug.test
 node_modules
 site/.firebaserc
 site/.firebase/**
-site/package.json


### PR DESCRIPTION
Working with this repo I realised that `site/package.json` is checked in but ignored for quite some time now.
And as dependencies and `npm run`s are triggered from there I assume this is not intended to be ignored from changes.