### PR TITLE
Change Movielens Download Dataset link to be https

### DIFF
--- a/site/sfguides/src/recommendation_engine_aws_sagemaker/recommendation_engine_aws_sagemaker.md
+++ b/site/sfguides/src/recommendation_engine_aws_sagemaker/recommendation_engine_aws_sagemaker.md
@@ -47,7 +47,7 @@ Duration: 5
 The first thing you'll need to do is download a small version of the dataset. Once downloaded, unzip the folder.
 
 <button>
-  [Download Dataset](http://files.grouplens.org/datasets/movielens/ml-latest-small.zip)
+  [Download Dataset](https://files.grouplens.org/datasets/movielens/ml-latest-small.zip)
 </button>
 
 We're going to take that data and load it into some tables on Snowflake. First, you'll want to sign in to Snowflake. Then run the following block of code to set the context, create a compute warehouse, and create the tables:


### PR DESCRIPTION
The files.grouplens.org server doesn't respond to HTTP, only HTTPS. Some browsers may correct for this, but not all. This change adds precisely one character, which corrects the download link to HTTPS. 