### PR TITLE
Bugfix for number encrypt, decrypt and format UDF

### DIFF
--- a/site/sfguides/src/python_camouflage/python_camouflage.md
+++ b/site/sfguides/src/python_camouflage/python_camouflage.md
@@ -829,23 +829,31 @@ import json
 import re
 from decimal import *
 
+
+
 def udf(ff3key, ff3input, userkeys):
+
     userkeys=userkeys.replace("'","")
     ff3_userkey_dict=json.loads(userkeys)
     userkeys_list=[]
     userkeyslist=ff3_userkey_dict[ff3key[3:]]
-
+    
     ff3key=userkeyslist[0]
     tweak=userkeyslist[1]
     padding=userkeyslist[2]
-
+    
+    
     checkdecimal="." in str(ff3input)
-
+    
+    
+    
     if checkdecimal==False :
+    
         length=len(str(ff3input))
         lengthpadding=0
 
         c = FF3Cipher(ff3key, tweak)
+    
 
         if length<=6:
             plaintext=str(ff3input)
@@ -870,18 +878,26 @@ def udf(ff3key, ff3input, userkeys):
         if length==1:
             plaintext=str(ff3input)+padding
             lengthpadding=6
+            
+        if ff3input==0:
+            plaintext='000000'
+            lengthpadding=6
 
         ciphertext = c.encrypt(plaintext)
 
+        
         if length<10:
-            ciphertext=ciphertext+"0"+str(length)
+           ciphertext=ciphertext+"0"+str(length)
         else:
             ciphertext=ciphertext+str(length)
 
+
         ciphertext=str(lengthpadding)+ciphertext
         return int(ciphertext)
+        
+        
+    if checkdecimal==True :       
 
-    if checkdecimal==True :
         c = FF3Cipher(ff3key, tweak)
 
         value = str(ff3input)
@@ -903,6 +919,16 @@ def udf(ff3key, ff3input, userkeys):
         commais=commais
         detect_float=plaintext_org.split('.')
 
+        #dont try to encode more than 11 digits with decimal generally or more than 9 digits before or after the comma
+
+        #if len(detect_float[0]) >= 10:
+         #   print ("VALUE BEFORE COMMA TOO BIG NOT MORE THAN 9 DIGITS ALLOWED")
+        #if len(detect_float[1])>=10:
+        #    print("VALUE AFTER COMMA TOO BIG NOT MORE THAN 9 DIGITS ALLOWED")
+        #if len(detect_float[1])+len(detect_float[0])>=12:
+        #    print ("VALUE  TOO BIG NOT MORE THAN 11 DIGITS ALLOWED")
+
+
         plaintext =  value
         plaintext=plaintext.replace('.','')
         if ff3_padding !=None:
@@ -914,24 +940,26 @@ def udf(ff3key, ff3input, userkeys):
 
         beforecomma=len(detect_float[0])
         aftercomma=len(detect_float[1])
-
+        
         aftercommacheck=value
-
-        mo = re.match('.+([1-9])[^1-9]*$', aftercommacheck)
-        if mo !=  None:
-            lastposition=int(mo.start(1))
-            aftercommacheck=value[0:lastposition+1]
-            aftercommacheck=aftercommacheck.split('.')
-            aftercomma=len(aftercommacheck[1])
+        
+        mo = re.search('(?:(\.\d*?[1-9]+)|\.)0*$', aftercommacheck)
+        
+        if mo.group(1) !=  None:
+    
+            aftercommacheck=mo.group(1).replace('.','')
+            aftercomma=len(aftercommacheck)
+        
         else:
             aftercomma=0
 
         endresult=ciphertext
 
         endresult=str(commais)+endresult+str(beforecomma)+str(aftercomma)+str(lengthpadding)
-
+        
         return Decimal(endresult)
 $$;
+
 
 --- Install the number token formatting UDF
 create or replace function format_ff3_number_38_8_pass3(ff3input number(38,8))
@@ -940,27 +968,32 @@ language python
 runtime_version = 3.8
 handler = 'udf'
 as $$
-
 from decimal import *
 
+
+
 def udf(ff3input):
+
+    
     checkdecimal="." in str(ff3input)
-
+    
     if checkdecimal==False :
-
+    
         value=str(ff3input)
         length=int(value[-2:])
-
+        
         formatted=''
         formatted=value[1:]
         formatted=formatted[:-2]
         formatted=formatted[0:length]
+        #formatted='1'+formatted
         final=''
         addition=0
         numberofzeros=0
         nullen=''
         result=0
-
+        
+        
         if formatted[0]=='0':
             numberofzeros=length-1
             addition=length-numberofzeros
@@ -969,29 +1002,53 @@ def udf(ff3input):
             final=str(addition)+nullen
             result=int(formatted)+int(final)
             return result
-        return int(formatted)
+            
 
+        return int(formatted)
+        
     if checkdecimal==True :
+    
         value=str(ff3input).split('.')
         result=value[0]
-        result=result[1:]
-        result=result[:-1]
-        commas=result[-2:]
-        result=result[:-2]
-
-        beforecomma=int(commas[0])
-        aftercomma=int(commas[-1])
-
-        bcdigits=result[0:beforecomma]
-
-        if aftercomma!=0:
-            acdigits=result[-aftercomma:]
+        
+        if len(result)!=9:
+            result=result[1:]
+            result=result[:-1]
+            commas=result[-2:]
+            result=result[:-2]
+        
+            beforecomma=int(commas[0])
+            aftercomma=int(commas[-1])
+        
+            if beforecomma!=1:
+                bcdigits=value[0][0:beforecomma]
+        
+                if aftercomma!=0: 
+                    acdigits=value[0][-aftercomma:]
+                else:
+                    acdigits=0
+        
+                endresult=str(bcdigits)+'.'+str(acdigits)
+      
+                return Decimal(endresult)
+                
+            else:
+            
+                bcdigits=value[0][4]
+        
+                if aftercomma!=0: 
+                    acdigits=value[0][-aftercomma:]
+                else:
+                    acdigits=0
+        
+                endresult=str(bcdigits)+'.'+str(acdigits)
+      
+                return Decimal(endresult)              
+            
         else:
-            acdigits=0
+            endresult=result[5]
+            return Decimal(endresult)
 
-        endresult=str(bcdigits)+'.'+str(acdigits)
-
-        return Decimal(endresult)
 $$;
 
 --- Install the sql join formatting UDF for numbers.
@@ -1046,31 +1103,36 @@ from ff3 import FF3Cipher
 import json
 from decimal import *
 
+
+
 def udf(ff3key, ff3input, userkeys):
+
+
     userkeys=userkeys.replace("'","")
     ff3_userkey_dict=json.loads(userkeys)
     userkeys_list=[]
     userkeyslist=ff3_userkey_dict[ff3key[3:]]
-
+    
     ff3key=userkeyslist[0]
     tweak=userkeyslist[1]
     padding=userkeyslist[2]
-
+    
     checkdecimal="." in str(ff3input)
-
+    
     if checkdecimal==False :
-
+        
         lengthpadding=str(ff3input)[0]
         lengthpadding=int(lengthpadding)
         lengthpadding=lengthpadding-1
-
+    
         c = FF3Cipher(ff3key, tweak)
 
+        
         ciphertext=str(ff3input)[1:]
         ciphertext=ciphertext[:-2]
         decrypted = c.decrypt(ciphertext)
-        length=lengthpadding
-
+        length=lengthpadding 
+ 
         if length==5:
             decrypted=decrypted[:-5]
         if length==4:
@@ -1082,30 +1144,46 @@ def udf(ff3key, ff3input, userkeys):
         if length==1:
             decrypted=decrypted[:-1]
 
-        return int(decrypted)
+    
 
+        return int(decrypted)
+        
     if checkdecimal==True :
+    
         c = FF3Cipher(ff3key, tweak)
 
         value=str(ff3input)
         valuesplit=value.split('.')
-
+        
         plaintext_org=valuesplit[0]
-        plaintext_org=plaintext_org[1:]
-        plaintext_org=plaintext_org[:-3]
+        length_pt_org=len(valuesplit[0])
+        
+        
+        if length_pt_org==9:
+            ciphertext=str(plaintext_org)[1:]
+            ciphertext=ciphertext[:-2]
+            decrypted = c.decrypt(ciphertext)
+            
+            return Decimal(decrypted)
+        
+        else:    
+            plaintext_org=plaintext_org[1:]
+            plaintext_org=plaintext_org[:-3]
 
-        decrypted = c.decrypt(str(plaintext_org))
-        value=valuesplit[0]
-        lengthpadding=int(value[-1])
-        commais=int(value[0])
+            decrypted = c.decrypt(str(plaintext_org))
+            value=valuesplit[0]
+            lengthpadding=int(value[-1])
+            commais=int(value[0])
 
-        if lengthpadding==1:
+     
+            if lengthpadding==1:
                 decrypted=decrypted[:commais] + '.' + decrypted[commais:]
-        else:
+            else:
                 decrypted=decrypted[:-lengthpadding+1]
                 decrypted=decrypted[:commais] + '.' + decrypted[commais:]
 
-        return Decimal(decrypted)
+            return Decimal(decrypted)
+
 $$;
 
 -- Install string token USphone formatting UDFs.


### PR DESCRIPTION
There was a bug that impeded the encryption and decryption of 0s. The format function sometimes did not catch the right amounts of digits behind the comma. This was fixed with a more accurate regex search.