### PR TITLE
Changing category for security dashboards

### DIFF
--- a/site/sfguides/src/security_dashboards_for_snowflake/security_dashboards_for_snowflake.md
+++ b/site/sfguides/src/security_dashboards_for_snowflake/security_dashboards_for_snowflake.md
@@ -1,7 +1,7 @@
 author: Security Field CTO Team
 id: security_dashboards_for_snowflake
 summary: Walkthrough of creating security dashboards for Snowflake based on Snowflake audit and config data
-categories: security, audit
+categories: Cybersecurity, audit, 
 environments: web
 status: Published 
 feedback link: https://github.com/Snowflake-Labs/sfguides/issues


### PR DESCRIPTION
Sec dashboards quickstart currently has the category of "security" changing it to "cybersecurity" since that already exists and will make it easier to have everything in a group. 

The original author @sfc-gh-jsander is cool with the change as well