### PR TITLE
Add missing hyphen, remove "Gettingstarted" from Categories

### DIFF
--- a/site/sfguides/src/Accelerate_Data_Transformation_with_the_Telecom_Data_Cloud/vhol_snowflake_informatica_for_telco.md
+++ b/site/sfguides/src/Accelerate_Data_Transformation_with_the_Telecom_Data_Cloud/vhol_snowflake_informatica_for_telco.md
@@ -1,7 +1,7 @@
 author: 
 id: Accelerate_Data_Transformation_with_the_Telecom_Data_Cloud
 summary: This is a guide for getting started with Data Integration using Informatica Data Management Cloud
-categories: Getting Started
+categories: Getting-Started
 environments: web
 status: Published 
 feedback link: https://github.com/Snowflake-Labs/sfguides/issues


### PR DESCRIPTION
We had two overlapping categories: "Getting-Started" and "Gettingstarted". The latter was caused by a Quickstart using "Getting Started" as a category, and our tooling recognizes that as a new category, and created "Gettingstarted" for it. Adding a hyphen ensure it follows the format for categories, and removes the category from the category drop down on the site. See screenshot.

<img width="321" alt="Screenshot 2023-05-09 at 16 45 23" src="https://github.com/Snowflake-Labs/sfquickstarts/assets/125584630/89405f00-cff7-4517-9267-5fbba7fd892a">
