### PR TITLE
Fix casing inconsistencies in referenced filenames

### DIFF
--- a/site/sfguides/src/accelerating_data_teams_with_snowflake_and_dbt_cloud_hands_on_lab/accelerating_data_teams_with_snowflake_and_dbt_cloud_hands_on_lab.md
+++ b/site/sfguides/src/accelerating_data_teams_with_snowflake_and_dbt_cloud_hands_on_lab/accelerating_data_teams_with_snowflake_and_dbt_cloud_hands_on_lab.md
@@ -119,7 +119,7 @@ Duration: 5
 
 5. When you see the popup that says `Your partner account has been created`, click on `Activate`.
 
-    ![Activate Partner Connect](assets/snowflake_activate_partner_connect.png)
+    ![Activate Partner Connect](assets/Snowflake_activate_partner_connect.png)
 
 6. You should be redirected to a dbt Cloud registration page. Fill out the form and make sure to save the password somewhere for login in the future.
 

--- a/site/sfguides/src/build_customer_facing_applications_using_sigma__and_snowflake/build_customer_facing_applications_using_sigma_and_snowflake.md
+++ b/site/sfguides/src/build_customer_facing_applications_using_sigma__and_snowflake/build_customer_facing_applications_using_sigma_and_snowflake.md
@@ -388,7 +388,7 @@ Duration: 10
   1. First we will need to install Node.js. Node is going to allow us to set up a local server, as well as the front end portal, and securely embed our dashboards with row level security so that brands are not seeing each other's data. Download and install Node.js by going here: [https://nodejs.org/](https://nodejs.org/)
    - Note, there are many programming languages and libraries you can use to code a client and server side application, this just happens to be the one we will be using today. 
 
-   ![embed1](assets/embeddingtheworkbook_1.png)
+   ![embed1](assets/Embeddingtheworkbook_1.png)
 
   2. Once downloaded, double click on the download and go through the installation steps. This should only take a minute. 
 

--- a/site/sfguides/src/cloud_native_data_engineering_with_matillion_and_snowflake/cloud_native_data_engineering_with_matillion_and_snowflake.md
+++ b/site/sfguides/src/cloud_native_data_engineering_with_matillion_and_snowflake/cloud_native_data_engineering_with_matillion_and_snowflake.md
@@ -924,7 +924,7 @@ Columns: Select **Autofill**, to populate all the available columns and select t
 | `PORTFOLIO_VALUE`  |  `"AVG_PRICE" * "# SHARES"` |
 |  `UNREALIZED_GAINS` |  `("AVG_PRICE" * "# SHARES") - ("# SHARES" * "MARKETPLACE")` |
 
-![9-17](assets/9-17.png)
+![9-17](assets/9-17.PNG)
 
 Finally, we will write Cersei’s profits back to Snowflake using the **Rewrite** component, and update as follows:
 

--- a/site/sfguides/src/data_engineering_snowpark_streamlit_inegi/data_engineering_snowpark_streamlit_inegi.md
+++ b/site/sfguides/src/data_engineering_snowpark_streamlit_inegi/data_engineering_snowpark_streamlit_inegi.md
@@ -178,14 +178,14 @@ Abrir el archivo **02_INEGI_dataEngineering.ipynb** y ejecutar los dos primeros 
 
 
 Ejecutar el cell **#Activación** para crear los objetos y privilegios Snowflake 
-![VSC](assets/vsc3.png)
+![VSC](assets/VSC3.png)
 
 Ejecutar el cell **#Crear internal Stage** para la carga de datos JSON ya curados
-![VSC](assets/vsc4.png)
+![VSC](assets/VSC4.png)
 
 
 Ejecutar el cell **#Transformando a objeto Snowflake** para la colocación de datos en el objeto Snowflake tabla 
-![VSC](assets/vsc5.png)
+![VSC](assets/VSC5.png)
 
 
 
@@ -194,19 +194,19 @@ Ejecutar el cell **#Transformando a objeto Snowflake** para la colocación de da
 Duration: 15 
 
  Abrir el archivo **03_INEGI_dataModeling.ipynb** y ejecutar los dos primeros cells para cargar las librerías necesarias y activar la sesión a Snowflake. 
-![VSC](assets/vsc6.png)
+![VSC](assets/VSC6.png)
 
 Ejecutar el cell **#Crear vista** para crear la vista que tendrá los datos que incluyen transformación de datos JSON en tabla INEGI_RAW  
-![VSC](assets/vsc7.png)
+![VSC](assets/VSC7.png)
 
 Ejecutar el cell **#UDF declaración** para incorporar la función creada en python nom_entidad que servirá para convertir No. de entidad por nombre de entidad.
-![VSC](assets/vsc8.png)
+![VSC](assets/VSC8.png)
 
 Ejecutar el cell **#Vista con totales por entidad aplicando** para materializar datos aplicando UDF y que tendrá los totales máximos de población para cada entidad
-![VSC](assets/vsc9.png)
+![VSC](assets/VSC9.png)
 
 Ejecutar el cell **#Validar la vista solo con totales por entidad** para validar el contenido de la vista creada 
-![VSC](assets/vsc10.png) 
+![VSC](assets/VSC10.png) 
 
 
 

--- a/site/sfguides/src/end_to_end_machine_learning_with_dataiku/end_to_end_machine_learning_with_dataiku.md
+++ b/site/sfguides/src/end_to_end_machine_learning_with_dataiku/end_to_end_machine_learning_with_dataiku.md
@@ -553,7 +553,7 @@ Duration: 8
 
 Go to ```home screen``` clicking on home button. 
 
-![27](assets/SF-17.JPG)
+![27](assets/SF-17.jpg)
 
 
 `Select` the `Admin` from the list.

--- a/site/sfguides/src/getting_started_with_search_optimization/getting_started_with_search_optimization.md
+++ b/site/sfguides/src/getting_started_with_search_optimization/getting_started_with_search_optimization.md
@@ -62,7 +62,7 @@ The first step in the guide is to set up or log into Snowflake and set up a virt
 
 The Snowflake web interface has a lot to offer, but for now, switch your current role from the default `SYSADMIN` to `ACCOUNTADMIN`. 
 
-![worksheet-image](assets/worksheets.png)
+![worksheet-image](assets/Worksheets.png)
 
 This will allow you to create shared databases from Snowflake Marketplace listings. If you don't have the `ACCOUNTADMIN` role, switch to a role with `IMPORT SHARE` privileges instead.
 

--- a/site/sfguides/src/hex/hex_vhol.md
+++ b/site/sfguides/src/hex/hex_vhol.md
@@ -163,7 +163,7 @@ Now, we can connect to our Snowflake connection that we imported earlier. To do 
 *The cell created by this button will be positioned under the cell that is currently selected. Make sure that the cell you have selected is the markdown cell with the header "Establishing a secure connection to Snowflake." You'll know if this cell is selected because it'll be outlined in blue.*
 
 
-![](assets/vhol-Snowpark.gif)
+![](assets/vhol-snowpark.gif)
 
 We'll also add the following two lines at the end of the cell to let Snowpark know which schema and database we want to use throughout the project.
 

--- a/site/sfguides/src/processing_hl7_v2_messages_with_snowflake/processing_hl7_v2_messages_with_snowflake.md
+++ b/site/sfguides/src/processing_hl7_v2_messages_with_snowflake/processing_hl7_v2_messages_with_snowflake.md
@@ -16,7 +16,7 @@ This Quickstart is designed to help you understand the capabilities included in 
 
 Sign up for a free 30-day trial of Snowflake and follow along with this lab exercise. After completing the labs, you’ll be ready to start processing and managing your own HL7 V2.x messages in Snowflake.
 
-![Architecture](assets/architecture.png)
+![Architecture](assets/Architecture.png)
 
 
 ### Prerequisites


### PR DESCRIPTION
There are a handful of filename casing inconsistencies between the referenced filenames in the markdown files, and the actual filenames in the assets directories.

These cause `npm run serve` to fail in environments with case-sensitive filesystems (i.e. Ubuntu).

In this patch, I modified the casing of the referenced filenames in the markdown files only; filenames in /assets directories are unchanged.
