### PR TITLE
Conda updates, secrets file fix, copy clarity

### DIFF
--- a/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
+++ b/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
@@ -63,7 +63,7 @@ Complete the following steps in your local machine (or an equivalent dev environ
     ```
 4. Run the following command to create a Python 3.11 conda virtual environment:
     ```
-    conda create --name snowpark-llm-chatbot python=3.11 --yes
+    conda create --name snowpark-llm-chatbot python=3.11
     ```
 5. Activate the conda environment by running the following command:
     ```

--- a/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
+++ b/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
@@ -71,7 +71,7 @@ Complete the following steps in your local machine (or an equivalent dev environ
     ```
 8. Install Snowpark for Python, Streamlit, and OpenAI by running the following command:
     ```
-    conda install snowflake-snowpark-python openai
+    conda install snowflake-snowpark-python "openai>=1.0.0"
     conda install conda-forge::"streamlit>=1.28.2"
     ```
 
@@ -147,8 +147,17 @@ Since our application will connect to Snowflake and OpenAI, we need a way to sec
 1. Add a folder within your `llm-chatbot` folder called `.streamlit`. Using the command line, you can do this by entering `mkdir .streamlit`.
 2. Within the `.streamlit` folder, add a file called `secrets.toml`. Using the command line, you can do this by first navigating to the `.streamlit` folder via `cd .streamlit` and then entering `touch secrets.toml.`
 
+#### Add OpenAI credentials to `secrets.toml`
+We need to add our OpenAI API key to our secrets file. Add your OpenAI key to the secrets file with the following format (replace the placeholder API key with your actual API key).
+
+```toml
+# .streamlit/secrets.toml
+
+OPENAI_API_KEY = "sk-2v...X"
+```
+
 #### Add Snowflake credentials to `secrets.toml`
-We need to add the Snowflake `user`, `password`, `warehouse`, `role`, and `account` to our secrets file. Copy the following format, replacing the placeholder credentials with your actual credentials.
+We also need to add the Snowflake `user`, `password`, `warehouse`, `role`, and `account` to our secrets file. Copy the following format, replacing the placeholder credentials with your actual credentials.
 `account` should be your Snowflake account identifier, which you can locate by following the instructions outlined [here](https://docs.snowflake.com/en/user-guide/admin-account-identifier).
 
 If you prefer to use browser-based SSO to authenticate, replace `password = "<my_trial_pass>"` with `authenticator=EXTERNALBROWSER`.
@@ -156,21 +165,12 @@ If you prefer to use browser-based SSO to authenticate, replace `password = "<my
 ```toml
 # .streamlit/secrets.toml
 
-[connections.snowpark]
+[connections.snowflake]
 user = "<jdoe>"
 password = "<my_trial_pass>"
 warehouse = "COMPUTE_WH"
 role = "ACCOUNTADMIN"
 account = "<account-id>"
-```
-
-#### Add OpenAI credentials to `secrets.toml`
-We also need to add our OpenAI API key to our secrets file. Copy the following format, replacing the placeholder API key with your actual API key.
-
-```toml
-# .streamlit/secrets.toml
-
-OPENAI_API_KEY = "sk-2v...X"
 ```
 
 #### Full contents of secrets.toml
@@ -203,7 +203,7 @@ First, we'll validate our OpenAI credentials by asking GPT-3.5 a simple question
 
 ```python
 import streamlit as st
-import openai
+from openai import OpenAI
 
 client = OpenAI(api_key=st.secrets["OPENAI_API_KEY"])
 
@@ -224,7 +224,6 @@ st.write(completion.choices[0].message.content)
 Next, let's validate that our Snowflake credentials are working as expected.
 
 1. Append the following to `validate_credentials.py`. This snippet does the following:
-   * Imports the Streamlit package
    * Creates a Snowpark connection
    * Executes a query to pull the current warehouse and writes the result to the UI
 

--- a/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
+++ b/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
@@ -55,28 +55,24 @@ Duration: 8
 
 Complete the following steps in your local machine (or an equivalent dev environment):
 
-1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to manage a separate environment by selecting the appropriate installer link for your operating system and Python version from [Anaconda's website](https://docs.conda.io/en/latest/miniconda.html#latest-miniconda-installer-links).
+1. Install [Anaconda Distribution](https://docs.conda.io/en/latest/miniconda.html) to manage a separate environment by selecting the appropriate installer link for your operating system and Python version from [Anaconda's website](https://docs.conda.io/en/latest/miniconda.html#latest-miniconda-installer-links).
 2. Open the terminal or command prompt and create a folder for your project. Let's call it `llm-chatbot`.
-3. If you're using a machine with an Apple M1 chip, run the following command to use conda to create a Python 3.10 virtual environment, add the Snowflake conda channel, and install the numpy and pandas packages: 
+3. Make sure you are running the latest version of conda by running the following command:
     ```
-    conda create --name snowpark-llm-chatbot --override-channels -c https://repo.anaconda.com/pkgs/snowflake python=3.10 numpy pandas
+    conda update -n base conda
     ```
-    Activate the environment created by running `conda activate snowpark-llm-chatbot` and proceed to step 6 below.
-
-    If you're not using a machine with an Apple M1 chip, continue to step 4.
-
-4. Create a conda environment by running the following command:
+4. Run the following command to create a Python 3.11 conda virtual environment:
     ```
-    conda create --name snowpark-llm-chatbot -c https://repo.anaconda.com/pkgs/snowflake python=3.10
+    conda create --name snowpark-llm-chatbot python=3.11 --yes
     ```
 5. Activate the conda environment by running the following command:
     ```
     conda activate snowpark-llm-chatbot
     ```
-6. Install Snowpark for Python, Streamlit, and OpenAI by running the following command:
+8. Install Snowpark for Python, Streamlit, and OpenAI by running the following command:
     ```
-    conda install -c https://repo.anaconda.com/pkgs/snowflake snowflake-snowpark-python openai
-    conda install -c conda-forge "streamlit>=1.28.2"
+    conda install snowflake-snowpark-python openai
+    conda install conda-forge::"streamlit>=1.28.2"
     ```
 
 ### Troubleshooting `pyarrow` related issues
@@ -153,6 +149,7 @@ Since our application will connect to Snowflake and OpenAI, we need a way to sec
 
 #### Add Snowflake credentials to `secrets.toml`
 We need to add the Snowflake `user`, `password`, `warehouse`, `role`, and `account` to our secrets file. Copy the following format, replacing the placeholder credentials with your actual credentials.
+`account` should be your Snowflake account identifier, which you can locate by following the instructions outlined [here](https://docs.snowflake.com/en/user-guide/admin-account-identifier).
 
 If you prefer to use browser-based SSO to authenticate, replace `password = "<my_trial_pass>"` with `authenticator=EXTERNALBROWSER`.
 

--- a/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
+++ b/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
@@ -223,14 +223,12 @@ st.write(completion.choices[0].message.content)
 
 Next, let's validate that our Snowflake credentials are working as expected.
 
-1. Replace the contents of `validate_credentials.py` with the below code. This snippet does the following:
+1. Append the following to `validate_credentials.py`. This snippet does the following:
    * Imports the Streamlit package
    * Creates a Snowpark connection
    * Executes a query to pull the current warehouse and writes the result to the UI
 
 ```python
-import streamlit as st
-
 conn = st.connection("snowflake")
 df = conn.query("select current_warehouse()")
 st.write(df)

--- a/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
+++ b/site/sfguides/src/frosty_llm_chatbot_on_streamlit_snowflake/frosty_llm_chatbot_on_streamlit_snowflake.md
@@ -179,7 +179,7 @@ OPENAI_API_KEY = "sk-2v...X"
 
 OPENAI_API_KEY = "sk-2v...X"
 
-[connections.snowpark]
+[connections.snowflake]
 user = "<username>"
 password = "<password>"
 warehouse = "COMPUTE_WH"


### PR DESCRIPTION
- Switches to Python 3.11
- No longer need separate install process for M1 Mac
- Updates "snowpark" to "snowflake" in secrets file
- Fixes import statement for OpenAI api update
- Small copy changes