### PR TITLE
Fixed permissions issue for SPCS data app quickstart

### DIFF
--- a/site/sfguides/src/tasty_bytes_zero_to_spcs_app/tasty_bytes_zero_to_spcs_app.md
+++ b/site/sfguides/src/tasty_bytes_zero_to_spcs_app/tasty_bytes_zero_to_spcs_app.md
@@ -481,6 +481,9 @@ We can create the users like this:
 USE ROLE ACCOUNTADMIN;
 CREATE ROLE tasty_app_ext_role;
 
+GRANT USAGE ON DATABASE frostbyte_tasty_bytes TO ROLE tasty_app_ext_role;
+GRANT USAGE ON SCHEMA app TO ROLE tasty_app_ext_role;
+
 CREATE USER IF NOT EXISTS user1 PASSWORD='password1' MUST_CHANGE_PASSWORD=TRUE DEFAULT_ROLE=tasty_app_ext_role;
 GRANT ROLE tasty_app_ext_role TO USER user1;
 ```


### PR DESCRIPTION
Added a fix for missed permissions grant to external users in Quickstart Build a Data App and run it on Snowpark Container Services
https://quickstarts.snowflake.com/guide/build_a_data_app_and_run_it_on_Snowpark_container_services/