### PR TITLE
Fix «Url should be a scoped URL error» in vhol_data_lake.md

### DIFF
--- a/site/sfguides/src/vhol_data_lake/vhol_data_lake.md
+++ b/site/sfguides/src/vhol_data_lake/vhol_data_lake.md
@@ -529,7 +529,7 @@ Now this function can be called in queries to use the parsed results of PDFs.
 select
   relative_path,
   file_url,
-  read_pdf('@documents/' || relative_path)
+  read_pdf(build_scoped_file_url(@documents, relative_path))
 from directory(@documents)
 limit 5;
 ```


### PR DESCRIPTION
Use build_scoped_file_url when calling the read_pdf UDF, as per https://docs.snowflake.com/en/release-notes/bcr-bundles/2023_03/bcr-1008.

Fixes #1254