### PR TITLE
Document AI Quickstart - Fixing link to Source Code in Conclusions & Resources

### DIFF
--- a/site/sfguides/src/tasty_bytes_extracting_insights_with_docai/tasty_bytes_extracting_insights_with_doc_ai.md
+++ b/site/sfguides/src/tasty_bytes_extracting_insights_with_docai/tasty_bytes_extracting_insights_with_doc_ai.md
@@ -326,7 +326,7 @@ Duration: 1
 - How to Flatten Semi-Structured Data
 
 ### Related Resources
-- [Source Code on GitHub]()
+- [Source Code on GitHub](https://github.com/Snowflake-Labs/sfguide-tasty-bytes-extract-insights-from-unstructured-data-using-document-ai)
 - [Powered by Tasty Bytes - Quickstarts Table of Contents](https://quickstarts.snowflake.com/guide/tasty_bytes_introduction/index.html#3)
 - [Document AI](https://docs.snowflake.com/en/user-guide/snowflake-cortex/document-ai/overview)
 - [Snowflake's Artic-TILT LLM for Document AI Documentation]((https://www.snowflake.com/blog/arctic-tilt-compact-llm-advanced-document-ai/))


### PR DESCRIPTION
Missing Sample code link in Conclusion & Resources section