### PR TITLE
Bugfix: SQL was getting data from 2 days ago, not yesterday.

### DIFF
--- a/site/sfguides/src/getting_started_with_snowflake/getting_started_with_snowflake.md
+++ b/site/sfguides/src/getting_started_with_snowflake/getting_started_with_snowflake.md
@@ -733,7 +733,7 @@ SELECT
     meta.company_name,
     ts.date,
     ts.value AS post_market_close,
-    (ts.value / LAG(ts.value, 1) OVER (PARTITION BY meta.primary_ticker ORDER BY ts.date) - 1)::DOUBLE AS daily_return,
+    (ts.value / LAG(ts.value, 1) OVER (PARTITION BY meta.primary_ticker ORDER BY ts.date))::DOUBLE AS daily_return,
     AVG(ts.value) OVER (PARTITION BY meta.primary_ticker ORDER BY ts.date ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) AS five_day_moving_avg_price
 FROM Financial__Economic_Essentials.cybersyn.stock_price_timeseries ts
 INNER JOIN company_metadata meta
@@ -755,7 +755,7 @@ SELECT
     meta.company_name,
     ts.date,
     ts.value AS nasdaq_volume,
-    (ts.value / LAG(ts.value, 1) OVER (PARTITION BY meta.primary_ticker ORDER BY ts.date) - 1)::DOUBLE AS volume_change
+    (ts.value / LAG(ts.value, 1) OVER (PARTITION BY meta.primary_ticker ORDER BY ts.date))::DOUBLE AS volume_change
 FROM cybersyn.stock_price_timeseries ts
 INNER JOIN company_metadata meta
 ON ts.ticker = meta.primary_ticker
@@ -776,7 +776,7 @@ SELECT
     meta.company_name,
     ts.date,
     ts.value AS post_market_close,
-    (ts.value / LAG(ts.value, 1) OVER (PARTITION BY primary_ticker ORDER BY date) - 1)::DOUBLE AS daily_return,
+    (ts.value / LAG(ts.value, 1) OVER (PARTITION BY primary_ticker ORDER BY ts.date))::DOUBLE AS daily_return,
     AVG(ts.value) OVER (PARTITION BY primary_ticker ORDER BY date ROWS BETWEEN 4 PRECEDING AND CURRENT ROW) AS five_day_moving_avg_price
 FROM cybersyn.stock_price_timeseries ts
 INNER JOIN company_metadata meta


### PR DESCRIPTION
The column `daily_return` was using data from 2 days ago, not from yesterday. 

To prove, the below shows `today`, `how_it_was` and `how_it_should_be`.

```
SELECT    
    ts.date today,
    (LAG(ts.date, 1) OVER (PARTITION BY meta.primary_ticker ORDER BY ts.date) - 1)::date AS how_it_was_2days_ago,
    (LAG(ts.date, 1) OVER (PARTITION BY meta.primary_ticker ORDER BY ts.date))::date AS how_it_should_be_yesterday
FROM cybersyn.stock_price_timeseries ts
INNER JOIN company_metadata meta
ON ts.ticker = meta.primary_ticker
WHERE ts.variable_name = 'Nasdaq Volume';
```

It returns:

![image](https://github.com/Snowflake-Labs/sfquickstarts/assets/1012787/f0145125-2f6a-46c5-977a-7139be476d40)
