### PR TITLE
Update tasty_bytes_zero_to_spcs_app.md

### DIFF
--- a/site/sfguides/src/tasty_bytes_zero_to_spcs_app/tasty_bytes_zero_to_spcs_app.md
+++ b/site/sfguides/src/tasty_bytes_zero_to_spcs_app/tasty_bytes_zero_to_spcs_app.md
@@ -1419,6 +1419,13 @@ You can now view tasty_app in the browser.
   On Your Network:  http://10.244.2.15:4000
 ```
 
+Grant service role access to tasty_app_ext_role to the endpoints in the service:
+
+```sql
+GRANT SERVICE ROLE frontend_service!ALL_ENDPOINTS_USAGE TO ROLE tasty_app_ext_role;
+GRANT SERVICE ROLE backend_service!ALL_ENDPOINTS_USAGE TO ROLE tasty_app_ext_role;
+```
+
 ### Step 7.2 Testing the service
 
 We are now finally ready to test the application in a browser. In order to do that we need the public endpoint exposed by the frontend_service. Call `SHOW ENDPOINTS` to retrieve that:


### PR DESCRIPTION
This solves the issue: https://github.com/Snowflake-Labs/sfquickstarts/issues/1421

Without this service role access, the guide cannot be completed and you get a deny access to the service endpoint with the current roles setup.