### PR TITLE
Minor typos in tasty bytes quickstarts

### DIFF
--- a/site/sfguides/src/tasty_bytes_customer_experience_app/tasty_bytes_customer_experience_app.md
+++ b/site/sfguides/src/tasty_bytes_customer_experience_app/tasty_bytes_customer_experience_app.md
@@ -47,7 +47,7 @@ Open a new Snowsight worksheet and run all commands from setup.sql.
 
 - Download all files from the [app directory](https://github.com/Snowflake-Labs/sfguide-tasty-bytes-enhancing-customer-experience/tree/main/customer-experience-app/app). This includes the file in the pages subdirectory.
 - In Snowsight, change role to sysadmin
-- open the tasty_bytes_customer_support_email.app.customer_support_email_app stage
+- open the tasty_bytes_enhancing_customer_experience.app.enhance_customer_experience_app stage
 
 ![stage-location](assets/app-stage-location.png)
 

--- a/site/sfguides/src/tasty_bytes_zero_to_snowflake_geospatial/tb_zts_geospatial.md
+++ b/site/sfguides/src/tasty_bytes_zero_to_snowflake_geospatial/tb_zts_geospatial.md
@@ -167,7 +167,7 @@ JOIN tb_safegraph.public.frostbyte_tb_safegraph_s cpg
 
 ### Step 2 - Click Next -->
 
-## Creating Geograpy Points from Latitude and Longitude
+## Creating Geography Points from Latitude and Longitude
 Duration: 1
 
 ### Overview

--- a/site/sfguides/src/tasty_bytes_zero_to_snowflake_governance_with_horizon/tb_zts_governance_with_horizon.md
+++ b/site/sfguides/src/tasty_bytes_zero_to_snowflake_governance_with_horizon/tb_zts_governance_with_horizon.md
@@ -888,7 +888,7 @@ For Tasty Bytes, Access History is particularly important for Compliance, Auditi
 Within this step, we will walk through leveraging Access History to find when the last time our Raw data was read from and written to.
 
 > aside negative
-> Access History latency is up to 3 hours. If you have just recently setupb the Tasty Bytes environment, some of the queries below may not have results. 
+> Access History latency is up to 3 hours. If you have just recently set up the Tasty Bytes environment, some of the queries below may not have results. 
 >
 
 ### Step 1 - Leveraging Access History


### PR DESCRIPTION
A couple of minor typos in quickstart MD.

1 - [Tasty Bytes - Enhance Customer Experience Using Unstructured Data](https://quickstarts.snowflake.com/guide/tasty_bytes_customer_experience_app/index.html?index=..%2F..index#1) references the wrong db and stage name, it looks like a copy/paste error from another quickstart

| | |
|--|--|
| Current | `open the tasty_bytes_customer_support_email.app.customer_support_email_app stage` |
| Intended | `open the tasty_bytes_enhancing_customer_experience.app.enhance_customer_experience_app stage` |

2 - `Geograpy` should be `Geography`

3 - `setupb` should be `set up`

I accept the CLA (https://github.com/snowflakedb/CLA)
