### PR TITLE
fix task dependencies, minor changes in data_engineering_with_snowpark_python_intro

### DIFF
--- a/site/sfguides/src/data_engineering_with_snowpark_python_intro/data-engineering-with-snowpark-python-intro.md
+++ b/site/sfguides/src/data_engineering_with_snowpark_python_intro/data-engineering-with-snowpark-python-intro.md
@@ -569,13 +569,13 @@ If you are familiar with Apache Airflow, you might know how we can use `>>` oper
 Here is how we define the order of execution of the tasks in our dag:
 
 ```python
-dag_task3 >> dag_task1
-dag_task3 >> dag_task2
+dag_task1 >> dag_task3
+dag_task2 >> dag_task3
 ```
 
-The above definition `dag_task3 >> dag_task1` means that `dag_task3` is dependant on `dag_task1`.
+The above definition `dag_task1 >> dag_task3` means that `dag_task3` is dependant on `dag_task1`.
 
-Similarly, `dag_task3 >> dag_task2` means that `dag_task3` is dependant on `dag_task2`.
+Similarly, `dag_task2 >> dag_task3` means that `dag_task3` is dependant on `dag_task2`.
 
 ### Deploying the DAG
 

--- a/site/sfguides/src/data_engineering_with_snowpark_python_intro/data-engineering-with-snowpark-python-intro.md
+++ b/site/sfguides/src/data_engineering_with_snowpark_python_intro/data-engineering-with-snowpark-python-intro.md
@@ -669,7 +669,7 @@ You should now see all the queries run by your tasks!
 
 Duration: 2
 
-Once you're finished with the Quickstart and want to clean things up, you can simply run the `steps/09_teardown.sql`. Since this is a SQL script we will be using our native VS Code extension to execute it. So simply open the `steps/09_teardown.sql` script in VS Code and run the whole thing using the "Execute All Statements" button in the upper right corner of the editor window.
+Once you're finished with the Quickstart and want to clean things up, you can simply run the `steps/08_teardown.sql`. Since this is a SQL script we will be using our native VS Code extension to execute it. So simply open the `steps/08_teardown.sql` script in VS Code and run the whole thing using the "Execute All Statements" button in the upper right corner of the editor window.
 
 <!-- ------------------------ -->
 

--- a/site/sfguides/src/data_engineering_with_snowpark_python_intro/data-engineering-with-snowpark-python-intro.md
+++ b/site/sfguides/src/data_engineering_with_snowpark_python_intro/data-engineering-with-snowpark-python-intro.md
@@ -139,7 +139,9 @@ To put this in context, we are on step **#3** in our data flow overview:
 
 You can log into [Snowsight](https://docs.snowflake.com/en/user-guide/ui-snowsight.html#) or VS Code to create all the snowflake objects needed to work through this guide.
 
-For the purpose of this quickstart, we will use VS Code to run the SQL commands and create the Snowflake objects. You can open the sql file `steps/03_setup_snowflake.sql` in VS Code. You can click on the `Execute` option above every SQL command to run each command separately or click on `Execute All` to run all the commands sequentially.
+For the purpose of this quickstart, we will use VS Code to run the SQL commands and create the Snowflake objects. To do that, open the Snowflake extension tab on the left and use the account identifier and other credentials you previously entered in the SnowSQL config to sign in.
+
+You can now open the sql file `steps/03_setup_snowflake.sql` in VS Code. You can click on the `Execute` option above every SQL command to run each command separately or click on `Execute All` to run all the commands sequentially.
 
 ---
 

--- a/site/sfguides/src/data_engineering_with_snowpark_python_intro/data-engineering-with-snowpark-python-intro.md
+++ b/site/sfguides/src/data_engineering_with_snowpark_python_intro/data-engineering-with-snowpark-python-intro.md
@@ -110,7 +110,7 @@ Once the codepsace has been created and started you should see a hosted web-base
 ### Configure Snowflake Credentials
 We will not be directly using [the SnowSQL command line client](https://docs.snowflake.com/en/user-guide/snowsql.html) for this Quickstart, but we will be storing our Snowflake connection details in the SnowSQL config file located at `~/.snowsql/config`. A default config file was created for you during the codespace setup.
 
-The easiest way to edit the default `~/.snowsql/config` file is directly from VS Code in your codespace. Type `Command-P`, type (or paste) `~/.snowsql/config` and hit return. The SnowSQL config file should now be open. You just need to edit the file and replace the `accountname`, `username`, and `password` with your values. Then save and close the file.
+The easiest way to edit the default `~/.snowsql/config` file is directly from VS Code in your codespace. Type `Command-P`, type (or paste) `~/.snowsql/config` and hit return. The SnowSQL config file should now be open. You just need to edit the file and replace the `accountname`, `username`, and `password` with your values. See [here](https://docs.snowflake.com/en/user-guide/admin-account-identifier#finding-the-organization-and-account-name-for-an-account) on how to find the  account identifier, and make sure to replace the dot between the organization name and the account name with a hyphen. Then save and close the file.
 
 **Note:** The SnowCLI tool (and by extension this Quickstart) currently does not work with Key Pair authentication. It simply grabs your username and password details from the shared SnowSQL config file.
 


### PR DESCRIPTION
## Fix task dependencies

The source code for `DAGTask` says the following (abbreviated):

```python
    def __rshift__(self, other):
        """Implement task1 >> task2."""
        # ...
        tasks = _convert_func_to_task(other)
        self.add_successors(tasks)
        return tasks
```

So the `>>` operator seems to work in the opposite way to what the script says. `a >> b` means that `b` will run after `a`, not before.

This is also consistent with the [Airflow API](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html#task-dependencies).

## Minor changes

### Fix teardown script file name

See https://github.com/Snowflake-Labs/sfguide-data-engineering-with-snowpark-python-intro/blob/main/steps/08_teardown.sql.

### Link to account identifier docs

It wasn't obvious for me that the `accountname` field needs to be an account identifier. It was furthermore not obvious that clicking "Copy account identifier" in Snowsight requires further changes.

### Instruct to sign in to the Snowflake VS Code extension

It's not rocket science, but it's good to mention that in the script.