### PR TITLE
Temporarily hide AI Observability Quickstart until Launch on Thursday

### DIFF
--- a/site/sfguides/src/getting_started_with_ai_observability/getting_started_with_ai_observability.md
+++ b/site/sfguides/src/getting_started_with_ai_observability/getting_started_with_ai_observability.md
@@ -3,7 +3,7 @@ id: getting_started_with_ai_observability
 summary: This is a guide for getting started with Snowflake AI Observability.
 categories: Getting-Started
 environments: web
-status: Published
+status: hidden
 feedback link: https://github.com/Snowflake-Labs/sfguides/issues
 tags: Getting Started, AI, Observability, RAG, LLMs, TruLens, Snowflake
 


### PR DESCRIPTION
Please hide the quickstart until launch on thursday pending confirmation from PM