### PR TITLE
Update marketplace listing, add launch guide link

### DIFF
--- a/site/sfguides/src/create_ai_agents_on_snowflake_with_lang_ai/create_ai_agents_on_snowflake_with_lang_ai.md
+++ b/site/sfguides/src/create_ai_agents_on_snowflake_with_lang_ai/create_ai_agents_on_snowflake_with_lang_ai.md
@@ -191,7 +191,8 @@ Duration: 1
 By following this guide, you have successfully set up an AI Agent running on Snowflake to automate your data analysis tasks.
 
 ### Related Resources
-- [Marketplace Listing](https://app.snowflake.com/marketplace/listing/GZTSZ1TJ3IU/lang-ai-snowflake-ai-agents)
+- [Marketplace Listing](https://app.snowflake.com/marketplace/listing/GZTSZ1TJ3JN/lang-ai-snowflake-ai-agents)
+- [AI Agents Launch Guide](https://help.lang.ai/en/articles/11458138-ai-agents-launch-guide)
 - [Lang.ai Help Center](https://help.lang.ai/en/collections/9808378-build-your-first-ai-agent)
 
 ### What You Learned


### PR DESCRIPTION
This PR adds a simple change updating the marketplace link since we needed to republish it to change it from trial to a paid listing. It also adds a link to our launch guide.