### PR TITLE
pin trulens to 1.5.2

### DIFF
--- a/site/sfguides/src/getting_started_with_ai_observability/getting_started_with_ai_observability.md
+++ b/site/sfguides/src/getting_started_with_ai_observability/getting_started_with_ai_observability.md
@@ -60,7 +60,12 @@ To open the notebook, open [getting-started-with-ai-observability.ipynb](https:/
 
 Then, create a new Snowflake notebook by importing the notebook file in Snowsight.
 
-In your Snowflake notebook, install the following python packages from the Snowflake conda channel: `snowflake-ml-python` `snowflake.core` `trulens-core` `trulens-providers-cortex` `trulens-connectors-snowflake`
+In your Snowflake notebook, install the following python packages from the Snowflake conda channel:
+* `snowflake-ml-python`
+* `snowflake.core`
+* `trulens-core==1.5.2`
+* `trulens-providers-cortex==1.5.2`
+* `trulens-connectors-snowflake==1.5.2`
 
 Once we have a Snowflake notebook with the right packages installed, we are ready to go.
 


### PR DESCRIPTION
Pin TruLens packages to 1.5.2 in AI Observability quickstart at Anubhav Mishra's request. This is a temporary change.