### PR TITLE
Add option to narrow watch scope when `gulp serve`

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -44,6 +44,18 @@ $ gulp serve
 The output will include the address where the server is running
 (http://localhost:8000 by default).
 
+For local development and limiting the file `watch` scope to a single lab, add the `--lab` filter. This 
+dramatically will increase performance for a lab you are working with.
+
+```text
+$ gulp serve --lab <lab folder name>
+```
+
+For example:
+```text
+$ gulp serve --lab zero_to_snowflake
+```
+
 You can also serve the completely compiled and minified (prod) version with the
 `serve:dist` command. Always run this before publishing, as it will show you an
 replica of what will appear on staging/production.
@@ -359,6 +371,8 @@ is "html"
 `--codelab-source` - Google Doc ID from which to build codelab. This can be
 specified multiple times to build from multiple sources.
 
+`--lab` - name of the folder in local development. Set this parameter to the codelab folder you are working with
+to filter the `watch` and `compile` tasks down to a single lab you are working with. Applies to `gulp serve` and will massively improve performance.
 
 ## Testing
 

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -99,15 +99,6 @@ const STAGING_BUCKET = gcs.bucketName(args.stagingBucket || 'DEFAULT_STAGING_BUC
 // VIEWS_FILTER is the filter to use for view inclusion.
 const VIEWS_FILTER = args.viewsFilter || '*';
 
-gulp.task('help', (callback) => {
-    console.log('Gulp Commands:');
-    console.log('  gulp sass     - Compiles Sass files to CSS.');
-    console.log('  gulp js       - Minifies JavaScript files.');
-    console.log('  gulp default  - Runs default tasks (e.g., sass and js).');
-    console.log('  gulp help     - Displays this help message.');
-    callback(); // Signal task completion
-});
-
 // clean:build removes the build directory
 gulp.task('clean:build', (callback) => {
   return del('build')

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -99,6 +99,15 @@ const STAGING_BUCKET = gcs.bucketName(args.stagingBucket || 'DEFAULT_STAGING_BUC
 // VIEWS_FILTER is the filter to use for view inclusion.
 const VIEWS_FILTER = args.viewsFilter || '*';
 
+gulp.task('help', (callback) => {
+    console.log('Gulp Commands:');
+    console.log('  gulp sass     - Compiles Sass files to CSS.');
+    console.log('  gulp js       - Minifies JavaScript files.');
+    console.log('  gulp default  - Runs default tasks (e.g., sass and js).');
+    console.log('  gulp help     - Displays this help message.');
+    callback(); // Signal task completion
+});
+
 // clean:build removes the build directory
 gulp.task('clean:build', (callback) => {
   return del('build')
@@ -142,7 +151,8 @@ gulp.task('export:codelabs', (callback) => {
     // claat.run(CODELABS_SRC_DIR, 'export', CODELABS_ENVIRONMENT, CODELABS_FORMAT, DEFAULT_GA, "../../"+CODELABS_BUILD_DIR, sources, callback);
     claat.run(CODELABS_SRC_DIR, 'export', CODELABS_ENVIRONMENT, CODELABS_FORMAT, DEFAULT_GA, "../../" + CODELABS_BUILD_DIR, CODELABS_ELEMENTS_PREFIX, sources, callback);
   } else {
-    const sources = ["[^_]*/*.md"]; //export all markdown files in the src directory, except _imports
+    // limit sources to args.lab if specified, else all markdowns
+    const sources = args.lab ? [args.lab + '/*.md'] : ["[^_]*/*.md"]; //export all markdown files in the src directory (or lab directory), except _imports
     // claat.run(CODELABS_SRC_DIR, 'export', CODELABS_ENVIRONMENT, CODELABS_FORMAT, DEFAULT_GA, "../../"+CODELABS_BUILD_DIR, sources, callback);
     claat.run(CODELABS_SRC_DIR, 'export', CODELABS_ENVIRONMENT, CODELABS_FORMAT, DEFAULT_GA, "../../" + CODELABS_BUILD_DIR, CODELABS_ELEMENTS_PREFIX, sources, callback);
   }
@@ -382,9 +392,11 @@ gulp.task('watch:images', () => {
 
 // watch:codelabs watches image files for changes and updates them
 gulp.task('watch:codelabs', () => {
+  // filter to a specific lab, else watch all labs
+  const dir_filter = args.lab ? args.lab : '**';
   const srcs = [
-    CODELABS_SRC_DIR + '/**/*.md',
-    CODELABS_SRC_DIR + '/**/assets/*',
+    CODELABS_SRC_DIR + '/' + dir_filter + '/*.md',
+    CODELABS_SRC_DIR + '/' + dir_filter + '/assets/*',
   ]
   gulp.watch(srcs, gulp.series('build:codelabs'));
 });


### PR DESCRIPTION
Current `gulp serve` command watches all codelabs for changes. When a change is detected, publish all codelabs. 

This process can consume lots of CPU and does unnecessary work.

New behavior:
Add `--lab` option to the gulpfile so the following command narrows the watch scope down to a single lab (which is the most common use case). For example:
`gulp serve --lab zero_to_snowflake`

