### PR TITLE
Fix markup in Braze guide for VHOL

### DIFF
--- a/site/sfguides/src/braze-email-engagement-analytics-cortex/braze-email-engagement-analytics-cortex.md
+++ b/site/sfguides/src/braze-email-engagement-analytics-cortex/braze-email-engagement-analytics-cortex.md
@@ -771,9 +771,9 @@ def get_analyst_response(messages: List[Dict]) -> Tuple[Dict, Optional[str]]:
 * error code: `{parsed_content['error_code']}`
 
 Message:
-```
+
 {parsed_content['message']}
-```
+
         """
         return parsed_content, error_msg
 


### PR DESCRIPTION
Error located in a line of markup, fixed in advance of VHOL tomorrow. It was breaking the formatting and code on a part of a page.