### PR TITLE
fix: Update stage URL for citibike_trips

### DIFF
--- a/site/sfguides/src/getting_started_with_snowflake/assets/lab_scripts_OnlineZTS.sql
+++ b/site/sfguides/src/getting_started_with_snowflake/assets/lab_scripts_OnlineZTS.sql
@@ -31,7 +31,7 @@ create table trips
 
 -- 3.2 
 
-create or replace stage citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips';
+create or replace stage citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips-csv/';
 
 -- 3.2.4
 

--- a/site/sfguides/src/getting_started_with_snowflake_it/assets/lab_scripts_OnlineZTS.sql
+++ b/site/sfguides/src/getting_started_with_snowflake_it/assets/lab_scripts_OnlineZTS.sql
@@ -31,7 +31,7 @@ create table trips
 
 -- 3.2 
 
-create or replace stage citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips';
+create or replace stage citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips-csv/';
 
 -- 3.2.4
 

--- a/site/sfguides/src/getting_started_with_snowflake_ja/assets/lab_scripts_OnlineZTS.sql
+++ b/site/sfguides/src/getting_started_with_snowflake_ja/assets/lab_scripts_OnlineZTS.sql
@@ -31,7 +31,7 @@ create table trips
 
 -- 3.2 
 
-create or replace stage citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips';
+create or replace stage citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips-csv/';
 
 -- 3.2.4
 

--- a/site/sfguides/src/getting_started_with_snowflake_kr/assets/lab_scripts_OnlineZTS.sql
+++ b/site/sfguides/src/getting_started_with_snowflake_kr/assets/lab_scripts_OnlineZTS.sql
@@ -31,7 +31,7 @@ create table trips
 
 -- 3.2 
 
-create or replace stage citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips';
+create or replace stage citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips-csv/';
 
 -- 3.2.4
 


### PR DESCRIPTION
Resolves #207 and I also found https://stackoverflow.com/questions/72235656/snowflake-trial-data-in-wrong-format and https://github.com/Snowflake-Labs/schemachange/issues/111#issuecomment-1682437289

```sh
$ snow sql --query "create or replace stage test_citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips-csv/'"
create or replace stage test_citibike_trips url = 's3://snowflake-workshop-lab/citibike-trips-csv/'
+------------------------------------------------------+
| status                                               |
|------------------------------------------------------|
| Stage area TEST_CITIBIKE_TRIPS successfully created. |
+------------------------------------------------------+

$ snow sql --query "list @test_citibike_trips"
+------------------------------------------------------------------------------+
| name                 | size     | md5                 | last_modified        |
|----------------------+----------+---------------------+----------------------|
| s3://snowflake-works | 16792666 | 8109965bf03864203c6 | Tue, 11 Mar 2025     |
| hop-lab/citibike-tri |          | a1797009a3fd5       | 14:37:58 GMT         |
| ps-csv/2020/data_0_0 |          |                     |                      |
| _0.csv.gz            |          |                     |                      |
...
+------------------------------------------------------------------------------+

$ snow sql --query "drop stage test_citibike_trips"
+-------------------------------------------+
| status                                    |
|-------------------------------------------|
| TEST_CITIBIKE_TRIPS successfully dropped. |
+-------------------------------------------+
```