### PR TITLE
Improvement: Staging webhook only runs for less than 4 changed files

### DIFF
--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -431,3 +431,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           timeout: 600s
           delay: 60s
+          ignore: ''

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -412,19 +412,19 @@ jobs:
           payload=$(jq -n \
             --arg repo "$GITHUB_REPOSITORY" \
             --arg pr '${{ github.event.pull_request.number }}' \
-            --arg sha '${{ github.event.pull_request.head.sha }}'' \
+            --arg sha '${{ github.event.pull_request.head.sha }}' \
             --arg env "staging" \
             --arg checkrunid '${{ github.run_id }}' \ 
             --arg qname '${{ steps.detect.outputs.quickstart_name }}' \
             --argjson qnames '${{ steps.detect.outputs.quickstart_names_json }}' \
             --argjson qfolders '${{ steps.detect.outputs.quickstart_folders_json }}' \
-            '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, check_run_id:$checkrunid, quickstart_name:$qname, quickstart_names:$qnames, quickstart_folders:$qfolders}')
+            '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, check_run_id:($checkrunid|tonumber), quickstart_name:$qname, quickstart_names:$qnames, quickstart_folders:$qfolders}')
           echo "$payload" | jq .
           echo "Triggering webhook asynchronously..."
           curl -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload" --max-time 5 --connect-timeout 2 > /dev/null 2>&1 || true
           echo "Webhook call sent (response will be handled asynchronously by external tool)"
 
-      - name: Wait for tests to succeed
+      - name: Wait for Workato to succeed
         if: steps.check_relevant.outputs.has_relevant_changes == 'true' && steps.detect.outputs.md_file_count < 4
         uses: poseidon/wait-for-status-checks@v0.6.0
         with:

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -414,10 +414,11 @@ jobs:
             --arg pr "${{ github.event.pull_request.number }}" \
             --arg sha "${{ github.event.pull_request.head.sha }}" \
             --arg env "staging" \
+            --arg checkrunid "${{ github.run_id }}" \ 
             --arg qname "${{ steps.detect.outputs.quickstart_name }}" \
             --argjson qnames '${{ steps.detect.outputs.quickstart_names_json }}' \
             --argjson qfolders '${{ steps.detect.outputs.quickstart_folders_json }}' \
-            '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, quickstart_name:$qname, quickstart_names:$qnames, quickstart_folders:$qfolders}')
+            '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, check_run_id:$checkrunid, quickstart_name:$qname,quickstart_names:$qnames, quickstart_folders:$qfolders}')
           echo "$payload" | jq .
           echo "Triggering webhook asynchronously..."
           curl -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload" --max-time 5 --connect-timeout 2 > /dev/null 2>&1 || true

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -285,7 +285,7 @@ jobs:
           fi
 
       - name: Comment PR with validation findings (on failure)
-        if: steps.check_relevant.outputs.has_relevant_changes == 'true' && (failure() || steps.check_large_files.outcome == 'failure') 
+        if: steps.check_relevant.outputs.has_relevant_changes == 'true' && (steps.check_large_files.outcome == 'failure' || steps.validate.outcome == 'failure' || steps.validate_categories.outcome == 'failure' || steps.validate_frontmatter.outcome == 'failure' || steps.validate_language.outcome == 'failure') 
         uses: actions/github-script@v7
         env:
           LARGE_FILES_JSON: ${{ steps.check_large_files.outputs.large_files_json }}

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -419,6 +419,19 @@ jobs:
             --argjson qfolders '${{ steps.detect.outputs.quickstart_folders_json }}' \
             '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, quickstart_name:$qname, quickstart_names:$qnames, quickstart_folders:$qfolders}')
           echo "$payload" | jq .
-          echo "Triggering webhook asynchronously..."
-          curl -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload" --max-time 5 --connect-timeout 2 > /dev/null 2>&1 || true
-          echo "Webhook call sent (response will be handled asynchronously by external tool)"
+          echo "Triggering webhook..."
+          response=$(curl -s -w "\n%{http_code}" -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload" --max-time 5 --connect-timeout 2) || {
+            exit_code=$?
+            echo "❌ Webhook call failed with exit code: $exit_code"
+            exit $exit_code
+          }
+          http_code=$(echo "$response" | tail -n1)
+          response_body=$(echo "$response" | sed '$d')
+          echo "HTTP Status Code: $http_code"
+          echo "Response body:"
+          echo "$response_body" | jq . 2>/dev/null || echo "$response_body"
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            echo "✅ Webhook call succeeded"
+          else
+            echo "⚠️ Webhook returned non-2xx status code: $http_code"
+          fi

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -407,14 +407,14 @@ jobs:
             --argjson qfolders '${{ steps.detect.outputs.quickstart_folders_json }}' \
             '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, quickstart_name:$qname, quickstart_names:$qnames, quickstart_folders:$qfolders}')
           echo "$payload" | jq .
-          http_code=$(curl -sS -w "%{http_code}" -o workato-response.json -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload" --max-time 600)
-          echo "HTTP Status Code: $http_code"
-          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-            echo "Error: Webhook returned HTTP $http_code"
-            cat workato-response.json
-            exit 1
-          fi
-          response=$(cat workato-response.json)
-          echo "$response" | jq .
-          url=$(jq -r '.urls.staging // .url // empty' workato-response.json)
-          if [ -n "$url" ]; then echo "staging_url=$url" >> $GITHUB_OUTPUT; fi
+          echo "Triggering webhook asynchronously..."
+          curl -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload" --max-time 5 --connect-timeout 2 > /dev/null 2>&1 || true
+          echo "Webhook call sent (response will be handled asynchronously by external tool)"
+
+      - name: Wait for tests to succeed
+        if: steps.check_relevant.outputs.has_relevant_changes == 'true'
+        uses: poseidon/wait-for-status-checks@v0.6.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 600s
+          delay: 60s

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -414,7 +414,7 @@ jobs:
             --arg pr '${{ github.event.pull_request.number }}' \
             --arg sha '${{ github.event.pull_request.head.sha }}' \
             --arg env "staging" \
-            --arg checkrunid '${{ github.run_id }}' \ 
+            --arg checkrunid '${{ github.run_id }}' \
             --arg qname '${{ steps.detect.outputs.quickstart_name }}' \
             --argjson qnames '${{ steps.detect.outputs.quickstart_names_json }}' \
             --argjson qfolders '${{ steps.detect.outputs.quickstart_folders_json }}' \

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -411,14 +411,14 @@ jobs:
         run: |
           payload=$(jq -n \
             --arg repo "$GITHUB_REPOSITORY" \
-            --arg pr "${{ github.event.pull_request.number }}" \
-            --arg sha "${{ github.event.pull_request.head.sha }}" \
+            --arg pr '${{ github.event.pull_request.number }}' \
+            --arg sha '${{ github.event.pull_request.head.sha }}'' \
             --arg env "staging" \
-            --arg checkrunid "${{ github.run_id }}" \ 
-            --arg qname "${{ steps.detect.outputs.quickstart_name }}" \
+            --arg checkrunid '${{ github.run_id }}' \ 
+            --arg qname '${{ steps.detect.outputs.quickstart_name }}' \
             --argjson qnames '${{ steps.detect.outputs.quickstart_names_json }}' \
             --argjson qfolders '${{ steps.detect.outputs.quickstart_folders_json }}' \
-            '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, check_run_id:$checkrunid, quickstart_name:$qname,quickstart_names:$qnames, quickstart_folders:$qfolders}')
+            '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, check_run_id:$checkrunid, quickstart_name:$qname, quickstart_names:$qnames, quickstart_folders:$qfolders}')
           echo "$payload" | jq .
           echo "Triggering webhook asynchronously..."
           curl -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload" --max-time 5 --connect-timeout 2 > /dev/null 2>&1 || true

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -431,7 +431,7 @@ jobs:
           echo "Response body:"
           echo "$response_body" | jq . 2>/dev/null || echo "$response_body"
           if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
-            echo "✅ Webhook call succeeded"
+            echo "✅ Webhook call succeeded. Please wait a few minutes for the staging environment to produce a preview URL."
           else
             echo "⚠️ Webhook returned non-2xx status code: $http_code"
           fi

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -407,7 +407,14 @@ jobs:
             --argjson qfolders '${{ steps.detect.outputs.quickstart_folders_json }}' \
             '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, quickstart_name:$qname, quickstart_names:$qnames, quickstart_folders:$qfolders}')
           echo "$payload" | jq .
-          response=$(curl -sS -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload")
-          echo "$response" > workato-response.json
+          http_code=$(curl -sS -w "%{http_code}" -o workato-response.json -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload" --max-time 600)
+          echo "HTTP Status Code: $http_code"
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Error: Webhook returned HTTP $http_code"
+            cat workato-response.json
+            exit 1
+          fi
+          response=$(cat workato-response.json)
+          echo "$response" | jq .
           url=$(jq -r '.urls.staging // .url // empty' workato-response.json)
           if [ -n "$url" ]; then echo "staging_url=$url" >> $GITHUB_OUTPUT; fi

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -159,11 +159,19 @@ jobs:
             all_changed_files_json=$(printf '%s\n' "$all_changed_files" | jq -R -s -c 'split("\n") | map(select(length>0))')
           fi
 
+          # Count markdown files
+          if [ -z "$md_files" ]; then
+            md_file_count=0
+          else
+            md_file_count=$(echo "$md_files" | wc -l | tr -d ' ')
+          fi
+
           echo "files_json=$files_arr" >> $GITHUB_OUTPUT
           echo "quickstart_names_json=$quickstart_names_json" >> $GITHUB_OUTPUT
           echo "quickstart_folders_json=$quickstart_folders_json" >> $GITHUB_OUTPUT
           echo "quickstart_name=$quickstart_name" >> $GITHUB_OUTPUT
           echo "all_changed_files_json=$all_changed_files_json" >> $GITHUB_OUTPUT
+          echo "md_file_count=$md_file_count" >> $GITHUB_OUTPUT
 
       - name: Check for large files
         if: steps.check_relevant.outputs.has_relevant_changes == 'true'
@@ -393,7 +401,7 @@ jobs:
           fi
 
       - name: Call Workato staging webhook
-        if: steps.check_relevant.outputs.has_relevant_changes == 'true'
+        if: steps.check_relevant.outputs.has_relevant_changes == 'true' && steps.detect.outputs.md_file_count < 4
         env:
           WORKATO_STAGING_WEBHOOK_URL: ${{ secrets.WORKATO_STAGING_WEBHOOK_URL }}
         run: |
@@ -412,7 +420,7 @@ jobs:
           echo "Webhook call sent (response will be handled asynchronously by external tool)"
 
       - name: Wait for tests to succeed
-        if: steps.check_relevant.outputs.has_relevant_changes == 'true'
+        if: steps.check_relevant.outputs.has_relevant_changes == 'true' && steps.detect.outputs.md_file_count < 4
         uses: poseidon/wait-for-status-checks@v0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -265,19 +265,23 @@ jobs:
             exit 0
           fi
           
-          invalid_count=$(echo "$objs" | jq '[ .[]
-            | if type=="object" and (.language|type)=="string"
+          # Filter to only include objects with invalid languages
+          invalid_objs=$(echo "$objs" | jq '[ .[]
+            | select(
+              if type=="object" and (.language|type)=="string"
               then (.language | ascii_downcase) as $l
-              | (["en","es","it","fr","de","ja","ko","pt_br"] | index($l))
-              | ( . == null )
+              | (["en","es","it","fr","de","ja","ko","pt_br"] | index($l)) == null
               else true
-            end
-          ] | map(select(.)) | length')
+              end
+            )
+          ]')
+          
+          invalid_count=$(echo "$invalid_objs" | jq 'length')
           
           if [ "$invalid_count" -ne 0 ]; then
             echo "Invalid or missing language detected. Allowed: en, es, it, fr, de, ja, ko, pt_br" >&2
-            echo "$objs" | jq . >&2
-            jq -n --argjson objs "$objs" --arg msg "Invalid or missing language detected. Allowed: en, es, it, fr, de, ja, ko, pt_br" '{type:"language", message:$msg, objects:$objs}' > validation-error.json
+            echo "$invalid_objs" | jq . >&2
+            jq -n --argjson objs "$invalid_objs" --arg msg "Invalid or missing language detected. Allowed: en, es, it, fr, de, ja, ko, pt_br" '{type:"language", message:$msg, objects:$objs}' > validation-error.json
             exit 1
           else
             echo "Language validation passed"

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -285,7 +285,7 @@ jobs:
           fi
 
       - name: Comment PR with validation findings (on failure)
-        if: steps.check_relevant.outputs.has_relevant_changes == 'true' && (failure() || steps.check_large_files.outcome == 'failure') && github.event.pull_request.base.repo.full_name == github.repository
+        if: steps.check_relevant.outputs.has_relevant_changes == 'true' && (failure() || steps.check_large_files.outcome == 'failure') 
         uses: actions/github-script@v7
         env:
           LARGE_FILES_JSON: ${{ steps.check_large_files.outputs.large_files_json }}

--- a/.github/workflows/validate-and-stage.yml
+++ b/.github/workflows/validate-and-stage.yml
@@ -414,21 +414,11 @@ jobs:
             --arg pr '${{ github.event.pull_request.number }}' \
             --arg sha '${{ github.event.pull_request.head.sha }}' \
             --arg env "staging" \
-            --arg checkrunid '${{ github.run_id }}' \
             --arg qname '${{ steps.detect.outputs.quickstart_name }}' \
             --argjson qnames '${{ steps.detect.outputs.quickstart_names_json }}' \
             --argjson qfolders '${{ steps.detect.outputs.quickstart_folders_json }}' \
-            '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, check_run_id:($checkrunid|tonumber), quickstart_name:$qname, quickstart_names:$qnames, quickstart_folders:$qfolders}')
+            '{repo:$repo, pr_number: ($pr|tonumber), commit_sha:$sha, environment:$env, quickstart_name:$qname, quickstart_names:$qnames, quickstart_folders:$qfolders}')
           echo "$payload" | jq .
           echo "Triggering webhook asynchronously..."
           curl -X POST "$WORKATO_STAGING_WEBHOOK_URL" -H "Content-Type: application/json" --data-raw "$payload" --max-time 5 --connect-timeout 2 > /dev/null 2>&1 || true
           echo "Webhook call sent (response will be handled asynchronously by external tool)"
-
-      - name: Wait for Workato to succeed
-        if: steps.check_relevant.outputs.has_relevant_changes == 'true' && steps.detect.outputs.md_file_count < 4
-        uses: poseidon/wait-for-status-checks@v0.6.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          timeout: 600s
-          delay: 60s
-          ignore: ''

--- a/site/sfguides/src/a-comprehensive-guide-creating-graphql-api-on-top-of-snowflake-using-propel/a-comprehensive-guide-creating-graphql-api-on-top-of-snowflake-using-propel.md
+++ b/site/sfguides/src/a-comprehensive-guide-creating-graphql-api-on-top-of-snowflake-using-propel/a-comprehensive-guide-creating-graphql-api-on-top-of-snowflake-using-propel.md
@@ -38,7 +38,6 @@ If you prefer a video overview, feel free to take a look at our interview with S
 Let's proceed.
 
 
-<!-- ------------------------ -->
 ## **Setting Up Example Data (Optional)**
 
 ### **Overview**

--- a/site/sfguides/src/a-comprehensive-guide-creating-graphql-api-on-top-of-snowflake-using-propel/a-comprehensive-guide-creating-graphql-api-on-top-of-snowflake-using-propel.md
+++ b/site/sfguides/src/a-comprehensive-guide-creating-graphql-api-on-top-of-snowflake-using-propel/a-comprehensive-guide-creating-graphql-api-on-top-of-snowflake-using-propel.md
@@ -38,6 +38,7 @@ If you prefer a video overview, feel free to take a look at our interview with S
 Let's proceed.
 
 
+<!-- ------------------------ -->
 ## **Setting Up Example Data (Optional)**
 
 ### **Overview**


### PR DESCRIPTION
Staging webhook should run only if a small number of files are changed. Validation should run as expected. 
* tested on large file count PR here: https://github.com/Snowflake-Labs/sfquickstarts/pull/2616 

Additional bugfixes -- action wasn't returning validation comment correctly some of the time. Also we were printing out all files with all languages, not just problematic ones, in our error message. This is fixed too. 