### PR TITLE
[Fix] Reformat payload and only send relevant files

### DIFF
--- a/.github/workflows/publish-on-approval.yml
+++ b/.github/workflows/publish-on-approval.yml
@@ -13,7 +13,7 @@ jobs:
       has_relevant_changes: ${{ steps.detect.outputs.has_relevant_changes }}
       quickstart_batches_json: ${{ steps.detect.outputs.quickstart_batches_json }}
       pr_number: ${{ steps.pr.outputs.number }}
-      all_changed_files_json: ${{ steps.detect.outputs.all_changed_files_json }}
+      relevant_changed_files_json: ${{ steps.detect.outputs.relevant_changed_files_json }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -111,9 +111,10 @@ jobs:
           fi
           echo "quickstart_batches_json=${quickstart_batches_json:-[]}" >> $GITHUB_OUTPUT
           echo "has_relevant_changes=$has_relevant_changes" >> $GITHUB_OUTPUT
-          # Output all changed files as JSON array for use in webhook payload
-          all_changed_files_json=$(echo "$changed_files" | jq -R -s -c 'split("\n") | map(select(length>0))')
-          echo "all_changed_files_json=$all_changed_files_json" >> $GITHUB_OUTPUT
+          # Output only relevant changed files as JSON array for use in webhook payload
+          # (markdown in root of quickstart folders + images in assets folders)
+          relevant_changed_files_json=$(echo "$relevant_files" | jq -R -s -c 'split("\n") | map(select(length>0))')
+          echo "relevant_changed_files_json=$relevant_changed_files_json" >> $GITHUB_OUTPUT
 
       - name: Get PR number from commit
         id: pr
@@ -142,7 +143,7 @@ jobs:
           WORKATO_PROD_WEBHOOK_URL: ${{ secrets.WORKATO_PROD_WEBHOOK_URL }}
           BATCH_JSON: ${{ toJson(matrix.batch) }}
           PR_NUMBER: ${{ needs.publish.outputs.pr_number }}
-          ALL_CHANGED_FILES_JSON: ${{ needs.publish.outputs.all_changed_files_json }}
+          RELEVANT_CHANGED_FILES_JSON: ${{ needs.publish.outputs.relevant_changed_files_json }}
         run: |
           if [ -z "$WORKATO_PROD_WEBHOOK_URL" ]; then
             echo "WORKATO_PROD_WEBHOOK_URL is not set. Cannot call production webhook." >&2
@@ -162,8 +163,9 @@ jobs:
             # Create single-item array for quickstart_names to match expected format
             qnames_array=$(jq -n --arg name "$qname" --arg lang "$qlang" '[{name:$name, language:$lang}]')
             
-            # Filter changed files to only those in this quickstart's directory
-            changed_files_for_qs=$(echo "$ALL_CHANGED_FILES_JSON" | jq -c --arg qname "$qname" '[.[] | select(startswith("site/sfguides/src/" + $qname + "/"))]')
+            # Filter relevant changed files to only those in this quickstart's directory
+            # Transform to array of objects with 'filename' property
+            changed_files_for_qs=$(echo "$RELEVANT_CHANGED_FILES_JSON" | jq -c --arg qname "$qname" '[.[] | select(startswith("site/sfguides/src/" + $qname + "/")) | {filename: .}]')
             
             payload=$(jq -n \
               --arg repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
Workato didn't like my array format so need to update it. 

Sample payload looks like this, which is as expected for current state of workato job. 

```
{
  "repo": "Snowflake-Labs/sfquickstarts",
  "commit_sha": "33d72258debd785a0718faf1db9d1d899a3ddd4f",
  "ref": "refs/heads/master",
  "environment": "prod",
  "pr_number": "2775",
  "quickstart_name": "ai-assistant-for-sales-calls",
  "quickstart_names": [
    {
      "name": "ai-assistant-for-sales-calls",
      "language": "en"
    }
  ],
  "changed_files": [
    {
      "filename": "site/sfguides/src/ai-assistant-for-sales-calls/ai-assistant-for-sales-calls.md"
    }
  ]
}
```