### PR TITLE
DCM Part 3: rename DEV_TEAM_1 to DT_TEAM_1 to avoid clash with Part 1

### DIFF
--- a/site/sfguides/src/dcm-projects-for-dynamic-tables/dcm-projects-for-dynamic-tables.md
+++ b/site/sfguides/src/dcm-projects-for-dynamic-tables/dcm-projects-for-dynamic-tables.md
@@ -194,7 +194,7 @@ templating:
       user: "INSERT_YOUR_USER"                          # update to your username
       project_owner_role: "DCM_DEVELOPER"
       teams:
-        - name: "DEV_TEAM_1"
+        - name: "DT_TEAM_1"
           data_retention_days: 1
           needs_sandbox_schema: true
 


### PR DESCRIPTION
Small follow-up: rename Part 3's DEV team so users running Parts 1 and 3 in the same account don't clash on team/role names. Companion: https://github.com/Snowflake-Labs/snowflake-dcm-projects/pull/29