### PR TITLE
ETCE-9089: Add journey markdown detection to publish and stage workflows

### DIFF
--- a/.github/workflows/publish-on-approval_no_workato.yml
+++ b/.github/workflows/publish-on-approval_no_workato.yml
@@ -15,6 +15,8 @@ jobs:
       relevant_changed_files_json: ${{ steps.detect.outputs.relevant_changed_files_json }}
       has_sidebar_changes: ${{ steps.detect.outputs.has_sidebar_changes }}
       sidebar_json_files: ${{ steps.detect.outputs.sidebar_json_files }}
+      journey_guides_json: ${{ steps.detect.outputs.journey_guides_json }}
+      has_journey_guides: ${{ steps.detect.outputs.has_journey_guides }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,6 +61,35 @@ jobs:
             echo "sidebar_json_files=[]" >> $GITHUB_OUTPUT
           fi
           
+          journey_md_changed=$(echo "$files_json" | jq -r '
+            .files[]? |
+            select(.status != "removed") |
+            .filename |
+            select(startswith("journeys/")) |
+            select(endswith(".md"))
+          ')
+          
+          if [ -n "$journey_md_changed" ]; then
+            echo "has_journey_guides=true" >> $GITHUB_OUTPUT
+            journey_objs='[]'
+            while IFS= read -r md_path; do
+              [ -z "$md_path" ] && continue
+              folder_path=$(dirname "$md_path")
+              guide_name=$(basename "$folder_path")
+              lang=""
+              if [ -f "$md_path" ]; then
+                lang=$(sed -n '1,50p' "$md_path" | grep -m1 -E '^[[:space:]]*language:[[:space:]]*' | sed -E 's/^[[:space:]]*language:[[:space:]]*//')
+                lang=$(printf '%s' "$lang" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
+              fi
+              journey_objs=$(echo "$journey_objs" | jq -c --arg name "$guide_name" --arg lang "$lang" --arg source "$folder_path" '. + [{name:$name, language:$lang, source_path:$source}]')
+            done <<< "$journey_md_changed"
+            echo "journey_guides_json=$journey_objs" >> $GITHUB_OUTPUT
+            has_relevant_changes=true
+          else
+            echo "has_journey_guides=false" >> $GITHUB_OUTPUT
+            echo "journey_guides_json=[]" >> $GITHUB_OUTPUT
+          fi
+          
           relevant_files=$(echo "$changed_files" | grep -E '^site/sfguides/src/[^/]+/([^/]+\.md|assets/[^/]+\.(jpg|jpeg|png|gif|svg|webp|bmp|ico))$' || true)
           quickstart_names=$(echo "$relevant_files" | sed -E 's|^site/sfguides/src/([^/]+)/.*|\1|' | grep -v '^_' | sort -u)
           
@@ -71,7 +102,7 @@ jobs:
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           
           has_relevant_changes=false
-          if [ -z "$quickstart_names" ] && [ -z "$sidebar_json_changed" ]; then
+          if [ -z "$quickstart_names" ] && [ -z "$sidebar_json_changed" ] && [ -z "$journey_md_changed" ]; then
             quickstart_names_json="[]"
             has_relevant_changes=false
           elif [ -z "$quickstart_names" ]; then
@@ -218,6 +249,28 @@ jobs:
       language: ${{ matrix.quickstart.language || 'en' }}
       commit_sha: ${{ github.sha }}
       base_image_url: ${{ vars.AEM_BASE_IMAGE_URL }}
+    secrets:
+      AEM_USERNAME: ${{ secrets.AEM_USERNAME_PROD }}
+      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_PROD }}
+      AEM_AUTHOR_URL: ${{ secrets.AEM_AUTHOR_URL_PROD }}
+      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL_PROD }}
+
+  publish_journey_guides:
+    needs: detect_changes
+    if: needs.detect_changes.outputs.has_journey_guides == 'true'
+    strategy:
+      matrix:
+        guide: ${{ fromJson(needs.detect_changes.outputs.journey_guides_json) }}
+      max-parallel: 1
+      fail-fast: false
+    uses: ./.github/workflows/publish-to-aem.yml
+    with:
+      quickstart_name: ${{ matrix.guide.name }}
+      language: ${{ matrix.guide.language || 'en' }}
+      commit_sha: ${{ github.sha }}
+      base_image_url: ${{ vars.AEM_BASE_IMAGE_URL }}
+      source_path: ${{ matrix.guide.source_path }}
+      page_base_path: /content/snowflake-site/global/en/developers/guides/journey-sidebar-base
     secrets:
       AEM_USERNAME: ${{ secrets.AEM_USERNAME_PROD }}
       AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_PROD }}

--- a/.github/workflows/publish-to-aem.yml
+++ b/.github/workflows/publish-to-aem.yml
@@ -19,6 +19,16 @@ on:
         description: 'Base URL for image references (e.g., CDN URL for prod, publish URL for dev/staging)'
         required: true
         type: string
+      source_path:
+        description: 'Path to the source folder containing the markdown (e.g., site/sfguides/src/my-guide or journeys/waf/my-guide)'
+        required: false
+        type: string
+        default: ''
+      page_base_path:
+        description: 'Base page path to clone from when creating new pages'
+        required: false
+        type: string
+        default: ''
     secrets:
       AEM_USERNAME:
         description: 'AEM username for basic auth'
@@ -36,7 +46,7 @@ on:
 env:
   BASE_CF_PATH: /content/dam/snowflake-site/en/content-fragments/base-fragments/base-quickstart-cf
   CF_DEST_PATH: /content/dam/snowflake-site
-  PAGE_BASE_PATH: /content/snowflake-site/global/en/developers/guides/quickstart-base
+  PAGE_BASE_PATH_DEFAULT: /content/snowflake-site/global/en/developers/guides/quickstart-base
   DAM_GUIDES_PATH: /content/dam/snowflake-site/developers/guides
 
 jobs:
@@ -55,7 +65,7 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha }}
           sparse-checkout: |
-            site/sfguides/src/${{ inputs.quickstart_name }}
+            ${{ inputs.source_path || format('site/sfguides/src/{0}', inputs.quickstart_name) }}
             scripts/aem-staging
           sparse-checkout-cone-mode: true
 
@@ -146,9 +156,10 @@ jobs:
       - name: Find markdown file
         id: find_md
         run: |
-          md_file=$(find "site/sfguides/src/${{ inputs.quickstart_name }}" -maxdepth 1 -name "*.md" -type f | head -n1)
+          search_path="${{ inputs.source_path || format('site/sfguides/src/{0}', inputs.quickstart_name) }}"
+          md_file=$(find "$search_path" -maxdepth 1 -name "*.md" -type f | head -n1)
           if [ -z "$md_file" ]; then
-            echo "❌ No markdown file found in ${{ inputs.quickstart_name }}"
+            echo "❌ No markdown file found in $search_path"
             exit 1
           fi
           echo "md_file=$md_file" >> $GITHUB_OUTPUT
@@ -256,7 +267,8 @@ jobs:
 
       - name: Upload images to AEM DAM
         run: |
-          assets_dir="site/sfguides/src/${{ inputs.quickstart_name }}/assets"
+          source_path="${{ inputs.source_path || format('site/sfguides/src/{0}', inputs.quickstart_name) }}"
+          assets_dir="${source_path}/assets"
           dam_folder="${DAM_GUIDES_PATH}/${{ inputs.quickstart_name }}"
           folder_exists="${{ steps.check_img_folder.outputs.folder_exists }}"
           
@@ -464,6 +476,7 @@ jobs:
           page_path="${{ steps.check_page.outputs.page_path }}"
           
           echo "📄 Creating page: $page_path"
+          PAGE_BASE_PATH="${{ inputs.page_base_path || env.PAGE_BASE_PATH_DEFAULT }}"
           echo "   Source: ${PAGE_BASE_PATH}"
           
           /tmp/aem_retry.sh POST "${AEM_URL}${PAGE_BASE_PATH}" \

--- a/.github/workflows/stage-to-aem.yml
+++ b/.github/workflows/stage-to-aem.yml
@@ -19,6 +19,16 @@ on:
         description: 'PR number for commenting'
         required: true
         type: number
+      source_path:
+        description: 'Path to the source folder containing the markdown'
+        required: false
+        type: string
+        default: ''
+      page_base_path:
+        description: 'Base page path to clone from when creating new pages'
+        required: false
+        type: string
+        default: ''
     secrets:
       AEM_USERNAME:
         description: 'AEM username for basic auth'
@@ -36,7 +46,7 @@ on:
 env:
   BASE_CF_PATH: /content/dam/snowflake-site/en/content-fragments/base-fragments/base-quickstart-cf
   CF_DEST_PATH: /content/dam/snowflake-site
-  PAGE_BASE_PATH: /content/snowflake-site/global/en/developers/guides/quickstart-base
+  PAGE_BASE_PATH_DEFAULT: /content/snowflake-site/global/en/developers/guides/quickstart-base
   DAM_GUIDES_PATH: /content/dam/snowflake-site/developers/guides
 
 jobs:
@@ -53,7 +63,7 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha }}
           sparse-checkout: |
-            site/sfguides/src/${{ inputs.quickstart_name }}
+            ${{ inputs.source_path || format('site/sfguides/src/{0}', inputs.quickstart_name) }}
             scripts/aem-staging
           sparse-checkout-cone-mode: true
 
@@ -69,7 +79,8 @@ jobs:
       - name: Find markdown file
         id: find_md
         run: |
-          md_file=$(find "site/sfguides/src/${{ inputs.quickstart_name }}" -maxdepth 1 -name "*.md" -type f | head -n1)
+          search_path="${{ inputs.source_path || format('site/sfguides/src/{0}', inputs.quickstart_name) }}"
+          md_file=$(find "$search_path" -maxdepth 1 -name "*.md" -type f | head -n1)
           if [ -z "$md_file" ]; then
             echo "❌ No markdown file found in ${{ inputs.quickstart_name }}"
             exit 1
@@ -278,7 +289,8 @@ jobs:
 
       - name: Collect and upload images
         run: |
-          assets_dir="site/sfguides/src/${{ inputs.quickstart_name }}/assets"
+          source_path="${{ inputs.source_path || format('site/sfguides/src/{0}', inputs.quickstart_name) }}"
+          assets_dir="${source_path}/assets"
           dam_folder="${DAM_GUIDES_PATH}/${{ inputs.quickstart_name }}"
           
           if [ ! -d "$assets_dir" ]; then
@@ -371,6 +383,7 @@ jobs:
       - name: Create staging page from base
         id: create_page
         run: |
+          PAGE_BASE_PATH="${{ inputs.page_base_path || env.PAGE_BASE_PATH_DEFAULT }}"
           page_name="${{ inputs.quickstart_name }}-${{ inputs.commit_sha }}"
           page_path="/content/snowflake-site/global/${{ inputs.language }}/developers/guides/${page_name}"
           title=$(jq -r '.title' parsed_content.json)

--- a/.github/workflows/validate-and-stage_no_workato.yml
+++ b/.github/workflows/validate-and-stage_no_workato.yml
@@ -22,6 +22,8 @@ jobs:
       md_file_count: ${{ steps.detect.outputs.md_file_count }}
       sidebar_json_files: ${{ steps.check_relevant.outputs.sidebar_json_files }}
       has_sidebar_changes: ${{ steps.check_relevant.outputs.has_sidebar_changes }}
+      journey_guides_json: ${{ steps.check_relevant.outputs.journey_guides_json }}
+      has_journey_guides: ${{ steps.check_relevant.outputs.has_journey_guides }}
       
     steps:
       - name: Check for relevant changes (early exit)
@@ -46,7 +48,23 @@ jobs:
             echo "sidebar_json_files=[]" >> $GITHUB_OUTPUT
           fi
           
-          if [ -z "$relevant_files" ] && [ -z "$sidebar_json_files" ]; then
+          journey_md_files=$(echo "$files_json" | jq -r '.[]?.filename | select(startswith("journeys/")) | select(endswith(".md"))')
+          if [ -n "$journey_md_files" ]; then
+            echo "has_journey_guides=true" >> $GITHUB_OUTPUT
+            journey_objs='[]'
+            while IFS= read -r md_path; do
+              [ -z "$md_path" ] && continue
+              folder_path=$(dirname "$md_path")
+              guide_name=$(basename "$folder_path")
+              journey_objs=$(echo "$journey_objs" | jq -c --arg name "$guide_name" --arg source "$folder_path" '. + [{name:$name, source_path:$source}]')
+            done <<< "$journey_md_files"
+            echo "journey_guides_json=$journey_objs" >> $GITHUB_OUTPUT
+          else
+            echo "has_journey_guides=false" >> $GITHUB_OUTPUT
+            echo "journey_guides_json=[]" >> $GITHUB_OUTPUT
+          fi
+          
+          if [ -z "$relevant_files" ] && [ -z "$sidebar_json_files" ] && [ -z "$journey_md_files" ]; then
             echo "has_relevant_changes=false" >> $GITHUB_OUTPUT
             echo ":information_source: No changes in site/sfguides/src/ or journeys/, skipping"
             exit 0
@@ -635,7 +653,8 @@ jobs:
     if: |
       needs.validate_and_stage_no_workato.outputs.has_relevant_changes == 'true' && 
       needs.validate_and_stage_no_workato.outputs.all_validations_passed == 'true' &&
-      needs.validate_and_stage_no_workato.outputs.md_file_count < 7
+      needs.validate_and_stage_no_workato.outputs.md_file_count < 7 &&
+      needs.validate_and_stage_no_workato.outputs.quickstart_names_json != '[]'
     strategy:
       matrix:
         quickstart: ${{ fromJson(needs.validate_and_stage_no_workato.outputs.quickstart_names_json) }}
@@ -719,3 +738,25 @@ jobs:
             bash scripts/upload-dam-asset.sh "$file" "snowflake-site/developers/technical/guides-navigation"
           done
           echo "✅ Sidebar JSON upload complete"
+
+  stage_journey_guides:
+    needs: validate_and_stage_no_workato
+    if: needs.validate_and_stage_no_workato.outputs.has_journey_guides == 'true'
+    strategy:
+      matrix:
+        guide: ${{ fromJson(needs.validate_and_stage_no_workato.outputs.journey_guides_json) }}
+      max-parallel: 1
+      fail-fast: false
+    uses: ./.github/workflows/stage-to-aem.yml
+    with:
+      quickstart_name: ${{ matrix.guide.name }}
+      language: en
+      commit_sha: ${{ github.event.pull_request.head.sha }}
+      pr_number: ${{ github.event.pull_request.number }}
+      source_path: ${{ matrix.guide.source_path }}
+      page_base_path: /content/snowflake-site/global/en/developers/guides/journey-sidebar-base
+    secrets:
+      AEM_USERNAME: ${{ secrets.AEM_USERNAME_STAGING }}
+      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_STAGING }}
+      AEM_AUTHOR_URL: ${{ secrets.AEM_AUTHOR_URL_STAGING }}
+      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL_STAGING }}


### PR DESCRIPTION
- Detect journeys/**/*.md changes in both publish and validate-and-stage
- Add source_path and page_base_path inputs to reusable workflows
- Journey guides use journey-sidebar-base template instead of quickstart-base
- Add stage_journey_guides and publish_journey_guides jobs
- Guard stage_to_aem job against empty quickstart matrix

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)