### PR TITLE
Add Posit Package Manager Public Preview callout to Posit quickstarts

### DIFF
--- a/site/sfguides/src/analyze-data-with-python-using-posit-team/analyze-data-with-python-using-posit-team.md
+++ b/site/sfguides/src/analyze-data-with-python-using-posit-team/analyze-data-with-python-using-posit-team.md
@@ -19,6 +19,8 @@ feedback link: https://github.com/Snowflake-Labs/sfguides/issues
 
 ## Overview
 
+> Learn more about the Posit Package Manager that just entered Public Preview at [this blog](https://posit.co/preview-link/node/14816/976bf2ac-6506-4ae1-99d7-62a19524b94b) and more about the Posit & Snowflake partnership [here](https://posit.co/preview-link/node/14811/6e8fefc5-a12f-40bc-8257-e141d80ae49f).
+
 In this guide, we'll use Python to analyze data in Snowflake using the Posit
 Team Native App. You'll learn how to launch the Posit Team Native App, access Posit Workbench, and use the available Positron Pro IDE. You'll also learn how to use the Ibis library to translate Python code into SQL, allowing you to run data operations directly in Snowflake's high-performance computing environment.
 

--- a/site/sfguides/src/build-and-deploy-interactive-dashboard-with-posit-team-and-cortex/build-and-deploy-interactive-dashboard-with-posit-team-and-cortex.md
+++ b/site/sfguides/src/build-and-deploy-interactive-dashboard-with-posit-team-and-cortex/build-and-deploy-interactive-dashboard-with-posit-team-and-cortex.md
@@ -11,6 +11,8 @@ feedback link: https://github.com/Snowflake-Labs/sfguides/issues
 
 ## Overview
 
+> Learn more about the Posit Package Manager that just entered Public Preview at [this blog](https://posit.co/preview-link/node/14816/976bf2ac-6506-4ae1-99d7-62a19524b94b) and more about the Posit & Snowflake partnership [here](https://posit.co/preview-link/node/14811/6e8fefc5-a12f-40bc-8257-e141d80ae49f).
+
 In this guide, we'll use the Posit Team Snowflake Native App to build an interactive dashboard that lets users explore Home Mortgage Disclosure Act (HMDA) data. In Posit Workbench, we'll use Positron Assistant and Databot with Snowflake Cortex AI to do some quick, yet powerful exploratory data analysis. Then, we'll create an interactive Shiny app and deploy it to Posit Connect in Snowflake with one-click publishing for easy sharing across your organization.
 
 ![](assets/guide-overview.png)


### PR DESCRIPTION
## Summary
- Adds a callout note box to the Overview section of both Posit Team quickstarts linking to the Posit Package Manager Public Preview blog and the Posit & Snowflake partnership announcement

## Quickstarts Updated
- `analyze-data-with-python-using-posit-team`
- `build-and-deploy-interactive-dashboard-with-posit-team-and-cortex`

## Test plan
- [ ] Verify callout renders correctly in the quickstart preview
- [ ] Confirm both hyperlinks resolve correctly

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)