### PR TITLE
Revert WAF sidebar JSON to subcategory + overview structure

### DIFF
--- a/journeys/well-architected-framework/well-architected-framework.json
+++ b/journeys/well-architected-framework/well-architected-framework.json
@@ -3,42 +3,91 @@
     {
       "id": "well-architected-framework",
       "label": "Well Architected Framework",
-      "subcategories": [],
-      "topics": [
+      "url": "https://www.snowflake.com/en/developers/guides/",
+      "subcategories": [
         {
           "id": "cost-optimization",
           "label": "Cost Optimization",
-          "url": "https://www.snowflake.com/en/developers/guides/cost-optimization/"
+          "url": "https://www.snowflake.com/en/developers/guides/cost-optimization/",
+          "topics": [
+            {
+              "id": "overview",
+              "label": "Overview",
+              "url": "https://www.snowflake.com/en/developers/guides/cost-optimization/#overview"
+            }
+          ]
         },
         {
           "id": "security-and-governance",
           "label": "Security & Governance",
-          "url": "https://www.snowflake.com/en/developers/guides/security-and-governance/"
+          "url": "https://www.snowflake.com/en/developers/guides/security-and-governance/",
+          "topics": [
+            {
+              "id": "overview",
+              "label": "Overview",
+              "url": "https://www.snowflake.com/en/developers/guides/security-and-governance/#overview"
+            }
+          ]
         },
         {
           "id": "reliability",
           "label": "Reliability",
-          "url": "https://www.snowflake.com/en/developers/guides/reliability/"
+          "url": "https://www.snowflake.com/en/developers/guides/reliability/",
+          "topics": [
+            {
+              "id": "overview",
+              "label": "Overview",
+              "url": "https://www.snowflake.com/en/developers/guides/reliability/#overview"
+            }
+          ]
         },
         {
           "id": "performance",
           "label": "Performance",
-          "url": "https://www.snowflake.com/en/developers/guides/performance/"
+          "url": "https://www.snowflake.com/en/developers/guides/performance/",
+          "topics": [
+            {
+              "id": "overview",
+              "label": "Overview",
+              "url": "https://www.snowflake.com/en/developers/guides/performance/#overview"
+            }
+          ]
         },
         {
           "id": "operational-excellence",
           "label": "Operational Excellence",
-          "url": "https://www.snowflake.com/en/developers/guides/operational-excellence/"
+          "url": "https://www.snowflake.com/en/developers/guides/operational-excellence/",
+          "topics": [
+            {
+              "id": "overview",
+              "label": "Overview",
+              "url": "https://www.snowflake.com/en/developers/guides/operational-excellence/#overview"
+            }
+          ]
         },
         {
           "id": "ai-data-governance-lens",
           "label": "AI & Data Governance Lens",
-          "url": "https://www.snowflake.com/en/developers/guides/ai-data-governance-lens/"
+          "url": "https://www.snowflake.com/en/developers/guides/ai-data-governance-lens/",
+          "topics": [
+            {
+              "id": "overview",
+              "label": "Overview",
+              "url": "https://www.snowflake.com/en/developers/guides/ai-data-governance-lens/#overview"
+            }
+          ]
         },
         {
           "id": "interoperable",
           "label": "Open and Interoperable",
-          "url": "https://www.snowflake.com/en/developers/guides/interoperable/"
+          "url": "https://www.snowflake.com/en/developers/guides/interoperable/",
+          "topics": [
+            {
+              "id": "overview",
+              "label": "Overview",
+              "url": "https://www.snowflake.com/en/developers/guides/interoperable/#overview"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Reverts the flattened pillars-as-topics WAF sidebar JSON which caused two overview sections to show up under each pillar on the live site.
- Restores the previous subcategory-per-pillar layout with a single Overview topic each.

## Test plan
- [ ] Verify reliability page (and other pillar pages) no longer show duplicate overview sections in the left nav
- [ ] Verify each pillar is still navigable from the WAF sidebar

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)