### PR TITLE
Republish cortex-code-foundations and accelerate-app-dev-cortex-code to AEM

### DIFF
--- a/site/sfguides/src/accelerate-app-dev-cortex-code/accelerate-app-dev-cortex-code.md
+++ b/site/sfguides/src/accelerate-app-dev-cortex-code/accelerate-app-dev-cortex-code.md
@@ -385,3 +385,4 @@ In this lab you built two fully functional AI applications from scratch on a Sno
 - [Cortex Code (Snowflake Copilot)](https://docs.snowflake.com/en/user-guide/snowflake-copilot)
 - [Getting Started with Cortex Agents — Quickstart](https://quickstarts.snowflake.com/guide/getting_started_with_cortex_agents)
 - [Streamlit in Snowflake](https://docs.snowflake.com/en/developer-guide/streamlit/about-streamlit)
+

--- a/site/sfguides/src/cortex-code-foundations/cortex-code-foundations.md
+++ b/site/sfguides/src/cortex-code-foundations/cortex-code-foundations.md
@@ -583,3 +583,4 @@ In Demo 1, that means a Dynamic Table, a small runbook from a bundled skill, and
 - [Cortex Agents Overview](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agent)
 - [Get Started with Snowflake Guides](https://www.snowflake.com/en/developers/guides/get-started-with-guides)
 - [sfguides GitHub Issues](https://github.com/Snowflake-Labs/sfguides/issues)
+


### PR DESCRIPTION
## Why

Both pages are currently returning 404 on snowflake.com:

- https://www.snowflake.com/en/developers/guides/cortex-code-foundations/
- https://www.snowflake.com/en/developers/guides/accelerate-app-dev-cortex-code/

Other guides (including all 6 PRs merged to master earlier today) are serving 200, so this isn't a site-wide outage. The source files in `master` are intact and well-formed — last edited May 8 (`cortex-code-foundations`) and May 26 (`accelerate-app-dev-cortex-code`) by @sfc-gh-kenguyen.

The `Publish to AEM (Without Workato)` workflow only fires `on: push: master` for files changed in that push, so neither page has been republished since their last edit. Something on the AEM side appears to have removed/unpublished them out of band.

## What

No-op trailing-newline touch to both quickstart markdowns so `publish-on-approval_no_workato.yml` detects the two changed quickstart folders and calls `publish-to-aem.yml` for each, republishing them.

## Verify after merge

```bash
for s in cortex-code-foundations accelerate-app-dev-cortex-code; do
  curl -sI -A "Mozilla/5.0" "https://www.snowflake.com/en/developers/guides/$s/" | head -1
done
```

Both should return `HTTP/2 200`.