### PR TITLE
cortex-code-control-hub: add skills docs (coco-hub-deploy, coco-hub-knowledge)

### DIFF
--- a/site/sfguides/src/cortex-code-control-hub/assets/code/skills/coco-hub-deploy/SKILL.md
+++ b/site/sfguides/src/cortex-code-control-hub/assets/code/skills/coco-hub-deploy/SKILL.md
@@ -1,0 +1,417 @@
+---
+name: coco-hub-deploy
+description: >
+  Interactive deployment guide for CoCo Control Hub (Cortex Code Credit Manager).
+  Invoke when someone wants to deploy, install, or set up CoCo Control Hub in
+  their Snowflake account. Asks targeted questions about their deployment target
+  (SPCS container vs warehouse Streamlit), database/schema, compute preferences,
+  existing admin roles, and account prerequisites. Guides them step-by-step
+  through the complete installation including Account Prerequisites (7 steps),
+  Phases A–E, post-install tasks, and common upgrade scenarios.
+  CRITICAL RULE: The app code must be deployed exactly as-is. No modifications
+  to any source files are permitted during deployment.
+triggers:
+  - deploy CoCo Control Hub
+  - install CoCo
+  - set up Cortex Code Credit Manager
+  - deploy the app
+  - how do I install
+  - deploy in my Snowflake account
+  - set up the credit manager
+  - redeploy
+  - upgrade CoCo
+---
+
+# CoCo Control Hub — Deployment Guide
+
+## CRITICAL RULE — Read First
+
+**The code must be deployed exactly as-is. Do NOT modify any source files.**
+
+- Do NOT edit `sp_definitions.py`, `config.py`, `prerequisites.sql`, `pages/*.py`, or `streamlit_app.py`
+- The ONLY files you may modify are `snowflake.yml` (deployment target) and `config.yaml` (admin roles + deployment database/schema)
+- All customisation happens through the app's Setup page AFTER deployment, never before
+
+---
+
+## Phase 0 — Gather Requirements
+
+Ask the user ALL of these questions before doing anything. Do not proceed until all are answered.
+
+### Question Set A — Deployment Type
+
+```
+1. How will you deploy the Streamlit app?
+   a) Streamlit on Warehouse (standard — no special compute needed)
+   b) Streamlit on Container (SPCS — requires compute pool, higher performance)
+```
+
+**If SPCS (b):** Also ask:
+- What is the name of your compute pool? (e.g. `COCO_HUB_POOL`)
+- Runtime: `SYSTEM_STREAMLIT_CONTAINER` (standard)
+
+### Question Set B — Snowflake Target
+
+```
+2. Where should the app be deployed?
+   - Database name (e.g. MY_DB)
+   - Schema name (e.g. APPS)
+   - Warehouse name (e.g. COMPUTE_WH, COCO_HUB_WH)
+```
+
+### Question Set C — Data Schema
+
+```
+3. Where should the app's data tables (CC_PROMPT_EVENTS, CC_USAGE_DAILY_SUMMARY, etc.) be stored?
+   a) Same database/schema as the app (most common — simpler)
+   b) Separate database/schema (for separation of concerns)
+```
+
+### Question Set D — Deployment Role
+
+```
+4. Which Snowflake role will you use to deploy the app and run Setup?
+   a) ACCOUNTADMIN (simplest — has all required privileges)
+   b) Custom role (e.g. PLATFORM_ADMIN, DBA_ROLE)
+      → If custom role: what is the role name?
+```
+
+### Question Set E — App Admin Roles
+
+```
+5. Which roles should see ALL admin pages in the app?
+   (These go in config.yaml → admin.roles)
+
+   a) Just ACCOUNTADMIN (default — safe starting point)
+   b) ACCOUNTADMIN + an existing org role (e.g. PLATFORM_ADMIN)
+      → What is the existing role name?
+   c) A completely custom new role you want to create specifically for CoCo
+
+   Note: End users (non-admins) only see Home and Credit Requests.
+   Admins see all 16 pages. You can add multiple roles.
+```
+
+### Question Set F — Existing Infrastructure
+
+```
+6. Do you already have:
+   [ ] A database and schema created (or will the deploy role create them?)
+   [ ] Cross-region inference enabled? (ALTER ACCOUNT SET CORTEX_ENABLED_CROSS_REGION = 'ANY')
+   [ ] AI Observability reader granted? (for prompt/token data)
+   [ ] ACCOUNT_USAGE access for the SP owner role? (for credit data)
+
+   Don't worry if not — the Setup page will guide you through all of these.
+```
+
+### Question Set G — Prerequisites Check
+
+```
+7. Confirm you have:
+   [ ] App code folder (git clone or zip)
+   [ ] Snowflake CLI installed: snow --version
+   [ ] Python 3.9+
+   [ ] Access to required Snowflake role (ACCOUNTADMIN or custom from Question D)
+```
+
+---
+
+## Phase 0b — Custom Role Privilege Setup
+
+**Only needed if Question D answer is (b) — custom role.**
+**Skip entirely if using ACCOUNTADMIN.**
+
+Run as ACCOUNTADMIN to grant the deploying role all needed privileges:
+
+```sql
+-- Replace MY_DEPLOY_ROLE, MY_DB, MY_SCHEMA, MY_WH with actual values
+USE ROLE ACCOUNTADMIN;
+
+-- 1. Database and schema access
+GRANT CREATE DATABASE ON ACCOUNT TO ROLE MY_DEPLOY_ROLE;       -- if DB doesn't exist yet
+GRANT USAGE ON DATABASE MY_DB TO ROLE MY_DEPLOY_ROLE;
+GRANT USAGE, CREATE SCHEMA ON DATABASE MY_DB TO ROLE MY_DEPLOY_ROLE;
+GRANT ALL ON SCHEMA MY_DB.MY_SCHEMA TO ROLE MY_DEPLOY_ROLE;
+GRANT USAGE ON WAREHOUSE MY_WH TO ROLE MY_DEPLOY_ROLE;
+
+-- 2. Streamlit deployment
+GRANT CREATE STREAMLIT ON SCHEMA MY_DB.MY_SCHEMA TO ROLE MY_DEPLOY_ROLE;
+GRANT CREATE STAGE ON SCHEMA MY_DB.MY_SCHEMA TO ROLE MY_DEPLOY_ROLE;
+
+-- 3. Object creation for Setup Phase A
+GRANT CREATE INTEGRATION ON ACCOUNT TO ROLE MY_DEPLOY_ROLE;
+GRANT CREATE TASK ON SCHEMA MY_DB.MY_SCHEMA TO ROLE MY_DEPLOY_ROLE;
+GRANT EXECUTE TASK ON ACCOUNT TO ROLE MY_DEPLOY_ROLE;
+GRANT EXECUTE ALERT ON ACCOUNT TO ROLE MY_DEPLOY_ROLE;
+GRANT CREATE STREAM ON SCHEMA MY_DB.MY_SCHEMA TO ROLE MY_DEPLOY_ROLE;
+GRANT CREATE ALERT ON SCHEMA MY_DB.MY_SCHEMA TO ROLE MY_DEPLOY_ROLE;
+GRANT CREATE PROCEDURE ON SCHEMA MY_DB.MY_SCHEMA TO ROLE MY_DEPLOY_ROLE;
+GRANT CREATE TABLE ON SCHEMA MY_DB.MY_SCHEMA TO ROLE MY_DEPLOY_ROLE;
+GRANT CREATE VIEW ON SCHEMA MY_DB.MY_SCHEMA TO ROLE MY_DEPLOY_ROLE;
+GRANT CREATE ROLE ON ACCOUNT TO ROLE MY_DEPLOY_ROLE;
+GRANT MANAGE GRANTS ON ACCOUNT TO ROLE MY_DEPLOY_ROLE;
+
+-- 4. Data access (for SP_CC_REFRESH_USAGE_SUMMARIES and SP_CC_CLASSIFY_PROMPTS)
+GRANT IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE TO ROLE MY_DEPLOY_ROLE;
+GRANT DATABASE ROLE SNOWFLAKE.AI_OBSERVABILITY_READER TO ROLE MY_DEPLOY_ROLE;
+
+-- 5. SPCS only (skip if Streamlit on Warehouse)
+GRANT USAGE ON COMPUTE POOL MY_COMPUTE_POOL TO ROLE MY_DEPLOY_ROLE;
+-- Or to create a new pool:
+-- GRANT CREATE COMPUTE POOL ON ACCOUNT TO ROLE MY_DEPLOY_ROLE;
+
+-- 6. Grant the deploy role to your user
+GRANT ROLE MY_DEPLOY_ROLE TO USER MY_USERNAME;
+```
+
+**If your security team won't grant MANAGE GRANTS:**
+Have a DBA run Setup Phase A under ACCOUNTADMIN, then use the custom role for all subsequent operations.
+
+---
+
+## Phase 1 — Configure the Two Files
+
+After gathering answers, update **only** these two files.
+
+### 1a. Update `snowflake.yml`
+
+**Streamlit on Warehouse:**
+```yaml
+definition_version: 2
+entities:
+  cortex_code_credit_manager:
+    type: streamlit
+    identifier:
+      name: CORTEX_CODE_CREDIT_MANAGER
+      database: <DATABASE>
+      schema: <SCHEMA>
+    title: "CoCo Control Hub"
+    query_warehouse: <WAREHOUSE>
+    main_file: streamlit_app.py
+    artifacts:
+      - config.py
+      - config.yaml
+      - .streamlit/config.toml
+      - audit.py
+      - utils.py
+      - intelligence.py
+      - sp_definitions.py
+      - prerequisites.sql
+      - environment.yml
+      - pages/__init__.py
+      - pages/home.py
+      - pages/access_management.py
+      - pages/credit_config.py
+      - pages/usage_trends.py
+      - pages/model_access.py
+      - pages/credit_requests.py
+      - pages/settings.py
+      - pages/audit_logs.py
+      - pages/setup.py
+      - pages/observability.py
+      - pages/cost_attribution.py
+      - pages/prompt_analysis.py
+      - pages/policy_rules.py
+      - pages/alerts.py
+      - pages/model_intelligence.py
+      - pages/user_intelligence.py
+    stage: CORTEX_CODE_CREDIT_MANAGER_STAGE
+```
+
+**Add these 2 lines for SPCS:**
+```yaml
+    runtime_name: SYSTEM_STREAMLIT_CONTAINER
+    compute_pool: <COMPUTE_POOL_NAME>
+```
+
+### 1b. Update `config.yaml`
+
+```yaml
+deployment:
+  database: ""    # Leave blank → uses CURRENT_DATABASE(). Or set: MY_DB
+  schema: ""      # Leave blank → uses CURRENT_SCHEMA(). Or set: APPS
+
+admin:
+  roles:
+    - ACCOUNTADMIN
+    # Add your existing org admin role here if applicable (from Question E):
+    # - PLATFORM_ADMIN
+    # - DBA_ROLE
+```
+
+**Important:** Do NOT put your personal dev account name (e.g. YOUR_DB, YOUR_SCHEMA). Leave blank if unsure — the sidebar Deployment Target picker overrides this at runtime.
+
+---
+
+## Phase 2 — Deploy the App
+
+```bash
+cd /path/to/cortex-code-credit-manager
+
+# Add connection if not set up
+snow connection add
+
+# Deploy
+snow streamlit deploy --replace --connection <connection_name>
+```
+
+Success: `Streamlit successfully deployed and available under https://app.snowflake.com/...`
+
+---
+
+## Phase 3 — Account Prerequisites (BEFORE Phase A)
+
+Open the app → **Setup** → expand **"⚡ Account Prerequisites"**. Run each SQL block in Snowsight as ACCOUNTADMIN. These are one-time account-level grants.
+
+| Step | SQL | Required? |
+|---|---|---|
+| 1 | `ALTER ACCOUNT SET CORTEX_ENABLED_CROSS_REGION = 'ANY'` | ✅ Needed for most models |
+| 2 | `GRANT DATABASE ROLE SNOWFLAKE.AI_OBSERVABILITY_READER TO ROLE CC_SP_OWNER_ROLE` | ✅ For prompt/token data |
+| 3 | `GRANT IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE TO ROLE CC_SP_OWNER_ROLE` | ✅ For credit/usage data |
+| 4 | `GRANT DATABASE ROLE SNOWFLAKE.CORTEX_USER TO ROLE CC_USER_ROLE` + `GRANT USE AI FUNCTIONS ON ACCOUNT TO ROLE CC_USER_ROLE` | ✅ For users to call AI functions |
+| 5 | `ALTER ACCOUNT SET CORTEX_CODE_CREDIT_LIMIT = N` | Optional |
+| 6 | AI Guardrails (Enterprise only) | Optional |
+| 7 | Native AI Budgets (Preview) | Optional |
+
+Status chips on the page show ✓ green (done) / ⚠ amber (not yet configured).
+
+---
+
+## Phase 4 — Run Setup Phases in the App
+
+Open the app → **Setup** sidebar. Run in order:
+
+| Phase | Button | What it does |
+|---|---|---|
+| **A** | Run Phase A — Create Objects | Creates all tables, roles, tasks, alerts, stream, email integration, seeds 8 policy rules |
+| A | Grant App Roles to Me | Grants CC_ADMIN_ROLE + CC_USER_ROLE to current user |
+| **B** | Run Phase B — Seed Defaults | Populates CC_APP_CONFIG with default settings |
+| **C** | Run Phase C — Create SPs | Creates SP_CC_CLASSIFY_PROMPTS, SP_CC_CHECK_ALERTS, SP_CC_EVALUATE_RESPONSES |
+| D1 | Run D1 — Backfill Usage | Backfill credit/usage history (pick 90 days) |
+| D2 | Run D2 — Backfill Prompts | Backfill prompt events, insights, surface detection (pick 90 days, 10–30 min) |
+| D3 | Run D3 — Model Config | Seed model tier config (one-time) |
+| D4 | Run D4 — Quality Eval | Custom Quality (Experimental) — optional, costs credits |
+| **E** | Run Phase E — Verify | Confirm all 70+ objects exist (green chips) |
+
+---
+
+## Phase 5 — Post-Install
+
+### Resume nightly tasks
+```sql
+ALTER TASK CC_CLASSIFY_PROMPTS_TASK RESUME;
+ALTER TASK CC_REFRESH_USAGE_SUMMARIES RESUME;
+-- Only if enforcing credit limits:
+-- ALTER TASK CC_DAILY_RESET_LIMITS RESUME;
+```
+
+### Enable email alerts
+Go to **Alerts → Notification Config** → enter recipient email → Save → Send Test Email
+
+### Grant app access to end users
+```sql
+GRANT ROLE CC_USER_ROLE TO USER <end_user>;
+-- Or to a department role:
+GRANT ROLE CC_USER_ROLE TO ROLE <department_role>;
+
+-- App visibility
+GRANT USAGE ON DATABASE <db> TO ROLE CC_USER_ROLE;
+GRANT USAGE ON SCHEMA <db>.<schema> TO ROLE CC_USER_ROLE;
+GRANT USAGE ON STREAMLIT <db>.<schema>.CORTEX_CODE_CREDIT_MANAGER TO ROLE CC_USER_ROLE;
+```
+
+### Add a custom admin role AFTER deploy
+If you want to add an existing org role (e.g. PLATFORM_ADMIN) as an app admin later:
+1. Edit `config.yaml` → add role to `admin.roles`
+2. Redeploy: `snow streamlit deploy --replace`
+3. No SP re-run needed — config.yaml is read at runtime
+
+---
+
+## Upgrade Path (code update on existing install)
+
+After pulling latest code and running `snow streamlit deploy --replace`:
+
+| What changed | Action needed |
+|---|---|
+| `pages/*.py` only | None — takes effect on reload |
+| `sp_definitions.py` | **Phase C** (recreate SPs) |
+| `sp_definitions.py` + new data needed | **Phase C** then **Phase D2** (re-backfill) |
+| `prerequisites.sql` (new tables) | **Phase A** (idempotent — safe to re-run) |
+| `config.yaml` admin roles | None — read at runtime |
+
+### New column migration (existing install)
+If upgrading from an older version that's missing columns:
+
+```sql
+USE DATABASE <db>;
+USE SCHEMA <schema>;
+
+ALTER TABLE IF EXISTS CC_PROMPT_EVENTS ADD COLUMN IF NOT EXISTS INPUT_TOKENS NUMBER;
+ALTER TABLE IF EXISTS CC_PROMPT_EVENTS ADD COLUMN IF NOT EXISTS OUTPUT_TOKENS NUMBER;
+ALTER TABLE IF EXISTS CC_PROMPT_EVENTS ADD COLUMN IF NOT EXISTS CACHE_READ_TOKENS NUMBER;
+ALTER TABLE IF EXISTS CC_PROMPT_EVENTS ADD COLUMN IF NOT EXISTS CACHE_WRITE_TOKENS NUMBER;
+ALTER TABLE IF EXISTS CC_PROMPT_EVENTS ADD COLUMN IF NOT EXISTS STEP_NUMBER NUMBER;
+ALTER TABLE IF EXISTS CC_PROMPT_EVENTS ADD COLUMN IF NOT EXISTS ENTRYPOINT VARCHAR(50);
+ALTER TABLE IF EXISTS CC_PROMPT_EVENTS ADD COLUMN IF NOT EXISTS PROMPT_CATEGORY VARCHAR(100);
+ALTER TABLE IF EXISTS CC_PROMPT_EVENTS ADD COLUMN IF NOT EXISTS PROMPT_COST_CREDITS FLOAT;
+```
+
+Then redeploy + Phase C + Phase D2.
+
+---
+
+## Common Issues
+
+| Error / Observation | Cause | Fix |
+|---|---|---|
+| `Database 'X' does not exist` | Wrong connection or snowflake.yml | Check connection and database |
+| `Insufficient privileges to MANAGE GRANTS` | Custom role missing MANAGE GRANTS | Grant it or run Phase A as ACCOUNTADMIN |
+| `AI_OBSERVABILITY_EVENTS not found` | Missing AI Observability reader | Grant `SNOWFLAKE.AI_OBSERVABILITY_READER` to CC_SP_OWNER_ROLE (Account Prerequisites Step 2) |
+| Phase E SHOW TASKS/ALERTS slow | Still running IN ACCOUNT | Ensure latest code deployed — now scoped to IN SCHEMA |
+| Snowsight sessions show as "Surface Unknown" | Snowflake doesn't populate `entrypoint` for Snowsight | Run Phase C (recreates SP with client_type fallback) + Phase D2 (re-backfill) |
+| Sessions show SDK-TYPESCRIPT | VS Code / TypeScript client surface | Expected — shown in "SDK / Extensions" bucket. Normal behaviour. |
+| `ALLOWED_RECIPIENTS` error on test email | Integration not configured | Save email in Alerts page first — auto-runs ALTER INTEGRATION |
+| `invalid identifier 'TIER'` in D3 | Old SP code | Redeploy, Phase C, then D3 |
+| Phase D2 very slow (20–40 min) | Large account with many spans | Normal — 90 days on 50K users. Reduce backfill window if needed. |
+| Prompt Intelligence numbers unchanged when changing period | CC_PROMPT_EVENTS only has data for periods SP was run | Run D2 with larger window to fill gaps |
+| GPT models show 100% Cache Hit Rate | OpenAI doesn't report cache_write tokens | Expected — shown as N/A in latest version. Re-deploy to get the fix. |
+| Custom Quality (Experimental) scores very low (0.2–0.3) | Evaluating planning steps not final responses | Run Phase C (updated SP), truncate CC_RESPONSE_QUALITY, re-run D4 |
+| Alert health shows STARTED but no alerts fire | All rules disabled in Alert Rules tab | Expected — scheduler runs but nothing triggers. Shows info message in latest version. |
+| "Pii Risk" showing in category chart | Old deploy with .str.title() bug | Redeploy — now shows "PII Risk" correctly |
+| Config.yaml has YOUR_DB/YOUR_SCHEMA | Developer's personal values were left in | Set database/schema to empty string — uses CURRENT_DATABASE/SCHEMA |
+| COCO_HUB_ADMIN role not found | Hardcoded in old config.yaml | Comment it out — config.yaml admin.roles should only have roles that exist in the account |
+
+---
+
+## Post-Deploy Data Correction SQLs
+
+### Fix system-injected prompts misclassified as documentation
+```sql
+UPDATE <db>.<schema>.CC_PROMPT_EVENTS
+SET PROMPT_CATEGORY = 'system_internal'
+WHERE PROMPT_CATEGORY IS NOT NULL
+  AND PROMPT_CATEGORY != 'system_internal'
+  AND (
+      LOWER(PROMPT) ILIKE 'cortex ctx task %'
+      OR LOWER(PROMPT) ILIKE 'cortex ctx step %'
+      OR LOWER(PROMPT) ILIKE 'cortex memory remember%'
+  );
+```
+
+### Clear low-quality evaluation scores and re-evaluate
+```sql
+TRUNCATE TABLE <db>.<schema>.CC_RESPONSE_QUALITY;
+-- Then run D4 in Setup → Phase D
+```
+
+---
+
+## What NOT to Do
+
+- **Do NOT** modify any `.py` files during deployment
+- **Do NOT** modify `prerequisites.sql`
+- **Do NOT** run `prerequisites.sql` directly — it has `__PLACEHOLDER__` tokens. Use Setup Phase A.
+- **Do NOT** enable `CC_DAILY_RESET_LIMITS` task unless you plan to enforce credit limits
+- **Do NOT** drop `CC_SP_OWNER_ROLE` — all SPs execute as this role
+- **Do NOT** leave `YOUR_DB` or `APPS` in config.yaml — use empty strings or your actual values
+- **Do NOT** add a role to config.yaml admin.roles that doesn't exist in the account (causes startup error)

--- a/site/sfguides/src/cortex-code-control-hub/assets/code/skills/coco-hub-knowledge/SKILL.md
+++ b/site/sfguides/src/cortex-code-control-hub/assets/code/skills/coco-hub-knowledge/SKILL.md
@@ -1,0 +1,525 @@
+---
+name: coco-hub-knowledge
+description: >
+  Complete knowledge base for CoCo Control Hub (Cortex Code Credit Manager v2).
+  Invoke whenever someone asks about the app's architecture, pages, data flow,
+  stored procedures, tables, analytics concepts, token economics, LLM-as-Judge
+  evaluation, responsible AI classification, alert system, prompt patterns,
+  latency interpretation, insight rates, cache efficiency, data sources,
+  or how to interpret any dashboard metric. Covers common questions, known
+  bugs, design decisions, and the full nightly SP pipeline.
+triggers:
+  - CoCo Control Hub
+  - Cortex Code Credit Manager
+  - how does the app work
+  - what does this page show
+  - explain the observability
+  - how are insights detected
+  - what is the nightly SP
+  - token economics
+  - LLM-as-Judge
+  - groundedness
+  - prompt patterns
+  - user intelligence
+  - cache hit rate
+  - how do I interpret
+  - why is output so small
+  - why are scores low
+  - insights more than prompts
+  - what does P95 mean
+  - where does data come from
+  - which event table
+  - system prompts filtered
+  - prompt insights
+---
+
+# CoCo Control Hub — Complete Knowledge Base
+
+## What the App Is
+
+CoCo Control Hub is a **Snowflake Streamlit** admin dashboard for governing Cortex Code usage across an enterprise. It gives administrators visibility into who is using Cortex Code AI, what they are asking, how much it costs, whether usage is compliant with responsible AI policies, and how the AI models are performing.
+
+Deployed as a Streamlit app (warehouse-mode or SPCS container) reading from:
+- `SNOWFLAKE.LOCAL.AI_OBSERVABILITY_EVENTS` — raw Cortex Code spans (nightly backfill)
+- `SNOWFLAKE.ACCOUNT_USAGE.*` — credit/usage history (nightly backfill)
+- Custom tables in the app schema (pre-aggregated, fast reads)
+
+---
+
+## Architecture
+
+```
+AI_OBSERVABILITY_EVENTS (raw spans, Snowflake-managed)
+         │
+         ▼  [SP_CC_CLASSIFY_PROMPTS — nightly 2am UTC]
+CC_PROMPT_EVENTS          ← typed columns, token economics, categories, cost
+CC_PROMPT_VIOLATIONS      ← policy violations per prompt
+CC_PROMPT_ANALYSIS_DAILY  ← per-user daily risk aggregation
+
+ACCOUNT_USAGE.* (credit history)
+         │
+         ▼  [SP_CC_REFRESH_USAGE_SUMMARIES — every 30 min]
+CC_USAGE_DAILY_SUMMARY    ← credits/tokens/requests by user+surface+date
+
+CC_PROMPT_EVENTS + ACCOUNT_USAGE (REQUEST_ID join, nightly)
+         │
+         ▼  [SP_CC_CLASSIFY_PROMPTS Step 6b]
+PROMPT_COST_CREDITS       ← actual billing per prompt
+
+CC_PROMPT_EVENTS → SP_CC_EVALUATE_RESPONSES (on demand)
+         │
+         ▼
+CC_RESPONSE_QUALITY       ← LLM-as-Judge scores per response
+```
+
+---
+
+## Pages & What They Show (sidebar order)
+
+| Page | Group | Purpose |
+|---|---|---|
+| **Home** | — | Executive snapshot: KPIs, surface split, top users, top LLMs, 7-day trend, health pulse |
+| **Setup** | Admin | 5-phase install: objects, defaults, SPs, data load, verify |
+| **Settings** | Admin | App config: eval model, credit pricing, alert email, backfill period |
+| **Audit Log** | Admin | All admin actions on this account |
+| **Access Management** | Access & Limits | Grant/revoke Cortex Code access by user or role |
+| **Credit Configuration** | Access & Limits | Credit limits at account → cohort → user level |
+| **Model Access** | Access & Limits | Tier management (TIER_1/2/3), role-model assignments |
+| **Credit Requests** | Access & Limits | Self-service credit increase requests |
+| **Usage Trends** | Usage & Cost | Credit burn over time, DAU, heatmap, spike detection, forecast |
+| **Cost Attribution** | Usage & Cost | Credits by cohort, top users by credits, per-prompt cost |
+| **AI Observability** | Observability | 11-tab span-level intelligence (see Observability Tabs below) |
+| **User Intelligence** | Observability | Full per-user profile: credits, tokens, insights, quality, prompt search |
+| **Prompt Insights** | Responsible AI | Risk dashboard, user governance profiles, full insights feed |
+| **Policy Rules** | Responsible AI | KEYWORD/REGEX/SEMANTIC rule CRUD |
+| **Alerts** | Responsible AI | Alert rules, history, email notifications |
+| **Model Intelligence** | Intelligence | LLM comparison: latency, token economics, LLM-as-Judge, insights, usage share |
+
+### AI Observability Tabs (11 total)
+Activity Trend · Top Users · Model Usage · Tool Calls · Prompt Browser · Sessions · Token Economics · Tool Intelligence · Entrypoints · Quality Scores · Prompt Patterns
+
+---
+
+## Key Tables
+
+| Table | Purpose | Populated by |
+|---|---|---|
+| `CC_PROMPT_EVENTS` | All prompts with 20+ columns: tokens, cache, steps, category, cost | SP_CC_CLASSIFY_PROMPTS (nightly) |
+| `CC_PROMPT_VIOLATIONS` | Policy violations per prompt | SP_CC_CLASSIFY_PROMPTS (nightly) |
+| `CC_PROMPT_ANALYSIS_DAILY` | Per-user daily risk aggregation | SP_CC_CLASSIFY_PROMPTS (nightly) |
+| `CC_USAGE_DAILY_SUMMARY` | Credits/tokens/queries by user+surface+date | SP_CC_REFRESH_USAGE_SUMMARIES (30min) |
+| `CC_RESPONSE_QUALITY` | LLM-as-Judge scores (4 dimensions) | SP_CC_EVALUATE_RESPONSES (on demand) |
+| `CC_POLICY_RULES` | Rule definitions (8 system defaults + custom) | Admin UI / seeded |
+| `CC_ALERT_CONFIG` | Alert thresholds | Admin UI / seeded |
+| `CC_APP_CONFIG` | All app settings (key-value) | Phase B seed |
+| `CC_MODEL_CONFIG` | Model tier assignments | Phase D3 seed |
+| `CC_CREDIT_CONFIG` | Credit limits per cohort/user | Credit Configuration page |
+
+### CC_PROMPT_EVENTS — key columns
+`MODEL`, `PROMPT`, `RESPONSE`, `LATENCY_MS`, `STATUS`, `REQUEST_ID`, `TOTAL_TOKENS`, `INPUT_TOKENS`, `OUTPUT_TOKENS`, `CACHE_READ_TOKENS`, `CACHE_WRITE_TOKENS`, `STEP_NUMBER`, `ENTRYPOINT`, `PRIVATE_MODE`, `PROMPT_CATEGORY`, `PROMPT_COST_CREDITS`
+Clustered by `EVENT_DATE` for fast date-range queries at 50K+ users.
+
+---
+
+## Stored Procedures
+
+| SP | Created by | Purpose |
+|---|---|---|
+| `SP_CC_REFRESH_USAGE_SUMMARIES` | Phase A | Incremental usage/credit aggregation from ACCOUNT_USAGE |
+| `SP_CC_CLASSIFY_PROMPTS(LOOKBACK_HOURS)` | Phase C | See detailed steps below |
+| `SP_CC_CHECK_ALERTS(MODE)` | Phase C | Batch + real-time alert evaluation with HTML email |
+| `SP_CC_EVALUATE_RESPONSES(BATCH_SIZE, EVAL_MODEL)` | Phase C | LLM-as-Judge: 4 evaluation dimensions |
+
+### SP_CC_CLASSIFY_PROMPTS — Steps
+1. Load new spans from AI_OBSERVABILITY_EVENTS (watermark-based, write_pandas — never in query history)
+2. **SQL KEYWORD classification** — `FLATTEN(CONDITIONS:keywords)` + `CONTAINS()` — single Snowflake query, scales to 50K users (replaced Python loops)
+3. REGEX classification — Python (session depth anomaly detection)
+4. SEMANTIC classification — `AI_CLASSIFY` on unique prompt hashes
+5. Count insights
+6. MERGE `CC_PROMPT_ANALYSIS_DAILY`
+6a-pre. **Mark system_internal prompts** — Cortex CLI commands (`cortex ctx task`, `cortex memory remember`, etc.) tagged as `system_internal` BEFORE AI_CLASSIFY runs
+6a. **Category classification** — `AI_CLASSIFY` assigns 1 of 8 categories to uncategorised prompts. Dedup by SHA2 hash, batch 50, cap 5K/night
+6b. **Cost attribution** — JOIN with `ACCOUNT_USAGE.CORTEX_CODE_*_USAGE_HISTORY` on REQUEST_ID → populate `PROMPT_COST_CREDITS`
+
+---
+
+## Analytics Concepts
+
+### Token Economics
+Data source: `CC_PROMPT_EVENTS` — extracted from `SNOWFLAKE.LOCAL.AI_OBSERVABILITY_EVENTS` span attribute `snow.ai.observability.agent.planning.token_count.*` via `CodingAgent.Step-0` spans.
+
+| Metric | What it is |
+|---|---|
+| **Input tokens** | Fresh prompt tokens processed from scratch — question, history, open files, tool definitions |
+| **Output tokens** | Tokens the LLM *generated* in its response |
+| **Cache Read tokens** | Tokens served from Snowflake's prompt cache — NOT re-processed, ~10× cheaper |
+| **Cache Write tokens** | Tokens written INTO the cache for the first time |
+| **Cache Hit Rate** | `cache_read / (cache_read + cache_write)` × 100. Higher = more credit savings. |
+
+### Custom Quality (Experimental) (Snowflake AI Observability terminology)
+| Metric | Definition |
+|---|---|
+| **Answer Relevance** | Did the LLM directly address what the user asked? (1.0 = fully answers) |
+| **Groundedness** | Factually grounded without hallucinating code, APIs, or functions? (1.0 = no hallucination) |
+| **Coherence** | Logically structured and clear? (1.0 = very clear) |
+| **Safety** | Free from harmful content? (1.0 = fully safe) |
+
+### Prompt Pattern Categories (AI_CLASSIFY — 8 types)
+`sql_data_engineering`, `agent_automation`, `code_review_debug`, `data_migration`, `data_modeling`, `analytics_reporting`, `documentation`, `general`
+
+### Policy Insight Categories
+| Category | What triggers it | Risk |
+|---|---|---|
+| `PII_RISK` | SSN, credit cards, passport, bank account | HIGH |
+| `SECURITY` | API keys, passwords, prompt injection, jailbreak, data exfiltration | HIGH |
+| `COMPETITOR` | Databricks, BigQuery, Redshift, Synapse, etc. | MEDIUM |
+| `USAGE_ANOMALY` | Session depth > threshold (automation/runaway agent) | MEDIUM |
+| `PERSONAL_USE` | Entertainment, personal errands, social content | LOW |
+
+### Composite Risk Score (User Intelligence)
+`risk_score = min(1.0, (high_violations × 0.15) + (violation_rate × 0.02) + max(0, 0.7 - safety_score))`
+Badges: ✅ Clean (< 0.25), ⚠️ Monitor (0.25–0.6), 🔴 Review (≥ 0.6)
+
+---
+
+## Common Questions & Answers
+
+### "Why is Output tokens only 0.1%? Don't I get output for every input?"
+
+Yes, you do get output for every input. The 0.1% is not wrong — it reflects the multi-step agent architecture:
+
+1. The `LATENCY_MS` and token counts come from **`CodingAgent.Step-0` spans** — one span per **agent reasoning step**, not per full user interaction
+2. Each Step-0 output = the planning decision for that step: "I'll use sql_execute tool" (~15 tokens) or "Let me read the file first" (~10 tokens)
+3. These short planning outputs make output look tiny compared to input
+4. The actual response the user reads spans multiple steps and is separately tracked in the `CodingAgentRun` span
+
+**Expected distribution for Cortex Code:**
+- Input: ~50% (fresh prompt tokens each step)
+- Cache Read: ~35-40% (system prompts, skill context served from cache)
+- Cache Write: ~10-15% (first-time caching)
+- Output: ~0.1-2% (planning decisions per step)
+
+This is normal and expected, not a data quality issue.
+
+### "Is 37% Cache Read normal? Is high cache read common?"
+
+37% cache hit rate is **excellent**. For Cortex Code specifically it is common and expected because:
+- Every session has a large fixed system prompt (skill instructions, tool definitions, coding guidelines)
+- These get cached after the first call and reused for all subsequent steps
+- Users who ask many follow-up questions in one session get higher cache hit rates
+- 37% means ~37% of all tokens were served at ~10× lower cost — real credit savings
+
+**Rule of thumb:**
+- > 20% cache hit: efficient, system is working well
+- < 5% cache hit: something wrong — skills not loading, very short sessions
+
+### "Why are my LLM-as-Judge scores so low (Answer Relevance: 0.22)?"
+
+Low scores are NOT because of the judge model (llama3.1-70b). The root cause is **evaluating intermediate planning steps, not final answers**:
+
+The SP was picking up ALL responses where `LENGTH > 20`, which includes:
+- "I'll use the sql_execute tool to run this query" (15 tokens → scores 0.1 relevance correctly)
+- "Let me read the file first" (8 tokens → same)
+
+These are agent planning decisions, not user-facing answers. The judge correctly scores them low.
+
+**Fix applied:** Filter `LENGTH(RESPONSE) > 200` + `ORDER BY STEP_NUMBER DESC` to only evaluate substantive final responses.
+
+**Expected scores after fix:** 0.65–0.85 range for Answer Relevance, Groundedness, and Coherence. Safety stays ~1.0.
+
+**To re-evaluate:** Truncate `CC_RESPONSE_QUALITY` and re-run D4 (Phase D → Run D4).
+
+### "P95 is 22.52s and P50 is 6.38s — does it take 22s on average?"
+
+No. The numbers mean:
+- **P50 = 6.38s** — 50% of all LLM calls completed in 6.38s or less. This is the **typical user experience**.
+- **P95 = 22.52s** — only the **slowest 5%** of calls exceed 22.52s. This is the worst-case threshold.
+
+The "average" is much closer to P50 (~6-8s), not P95.
+
+**Important nuance:** These are per-step latencies (one `CodingAgent.Step-0` span). A full user interaction has 3-5 steps:
+- 3 steps × P50 (6.38s) ≈ 19-20 seconds total end-to-end
+- This matches what users typically experience
+
+**Large P95 gap is normal** for Cortex Code because:
+- First call of session: cache is cold, all tokens processed fresh
+- Complex reasoning steps with 50K+ token contexts take longer
+- Multi-file operations add time
+- Occasional model-side load spikes on Snowflake infrastructure
+
+### "Insights show more than prompts — is that right?"
+
+No — this was a **JOIN fan-out bug** that has been fixed. The old query joined `CC_PROMPT_EVENTS` with `CC_PROMPT_VIOLATIONS` on `USER_NAME + DATE`. One user with 100 prompts and 50 violations on the same date produced 100 × 50 = 5,000 counted violations.
+
+**Fix:** Pre-aggregate insights per user+date with `COUNT(DISTINCT VIOLATION_ID)` in a CTE before joining to prompt events. After fix, insights should be a small fraction of prompts.
+
+### "Where does the token data come from? Which event table?"
+
+**Raw source:** `SNOWFLAKE.LOCAL.AI_OBSERVABILITY_EVENTS` — a Snowflake-managed event table automatically populated by Cortex Code. The token counts live in `RECORD_ATTRIBUTES`:
+
+```sql
+RECORD_ATTRIBUTES['snow.ai.observability.agent.planning.token_count.input']::INT
+RECORD_ATTRIBUTES['snow.ai.observability.agent.planning.token_count.output']::INT
+RECORD_ATTRIBUTES['snow.ai.observability.agent.planning.token_count.cache_read_input']::INT
+RECORD_ATTRIBUTES['snow.ai.observability.agent.planning.token_count.cache_write_input']::INT
+```
+
+Filter: `RECORD_TYPE = 'SPAN' AND RECORD:name::STRING = 'CodingAgent.Step-0'`
+
+**Lineage:** AI_OBSERVABILITY_EVENTS → `SP_CC_CLASSIFY_PROMPTS` (nightly) → `CC_PROMPT_EVENTS` (typed columns) → Dashboard charts (aggregate queries)
+
+The app never queries AI_OBSERVABILITY_EVENTS directly for dashboards — all reads go to `CC_PROMPT_EVENTS` (clustered, fast) or `CC_USAGE_DAILY_SUMMARY`.
+
+### "Why does 'documentation' appear as the top prompt category?"
+
+This happens when **system-injected Cortex CLI commands** get classified. Commands like:
+- `cortex memory remember "prefer tabs over spaces"`
+- `cortex ctx task add "Fix the bug"`
+- `cortex_memory_remember something`
+
+These look like documentation/instruction text to AI_CLASSIFY. The fix adds a `system_internal` pre-classification step (Step 6a-pre) that marks these before they reach AI_CLASSIFY.
+
+To fix existing misclassified rows:
+```sql
+UPDATE CC_PROMPT_EVENTS
+SET PROMPT_CATEGORY = 'system_internal'
+WHERE PROMPT_CATEGORY IS NOT NULL
+  AND PROMPT_CATEGORY != 'system_internal'
+  AND (
+      LOWER(PROMPT) ILIKE 'cortex ctx task %'
+      OR LOWER(PROMPT) ILIKE 'cortex ctx step %'
+      OR LOWER(PROMPT) ILIKE 'cortex memory remember%'
+      OR LOWER(PROMPT) ILIKE '%cortex_memory_remember%'
+  );
+```
+
+### "Phase C shows 4 SPs but only creates 3 — is something wrong?"
+
+No. `SP_CC_REFRESH_USAGE_SUMMARIES` is created by **Phase A** (from `prerequisites.sql`), not Phase C. Phase C creates the 3 SPs defined in `sp_definitions.py`:
+- `SP_CC_CLASSIFY_PROMPTS`
+- `SP_CC_CHECK_ALERTS`
+- `SP_CC_EVALUATE_RESPONSES`
+
+The table in Phase C shows all 4 SPs with a "Created by" column to clarify this.
+
+### "Setup Phase D — should I reload data after SP changes?"
+
+The watermark in `SP_CC_CLASSIFY_PROMPTS` prevents re-loading events that already exist. Only new events are loaded on each run. But:
+- **New columns (INPUT_TOKENS etc.)** on OLD rows stay NULL — watermark prevents re-processing
+- **Categories (PROMPT_CATEGORY)** ARE backfilled on all rows where `PROMPT_CATEGORY IS NULL` — no watermark needed
+- **Cost (PROMPT_COST_CREDITS)** IS backfilled on all rows where NULL
+
+For full column population on old rows: truncate `CC_PROMPT_EVENTS` and re-run D2 with 180 days.
+
+### "Can insights be more than prompts?"
+
+No, that should never happen. If it does it's the JOIN fan-out bug (see above). Expected insight rates:
+- Clean account: < 5 insights per 1,000 prompts
+- Active policy enforcement: 10-50 per 1,000
+- > 100 per 1,000 indicates data quality issue (likely fan-out bug)
+
+---
+
+## Data Privacy Design
+- Prompts/responses never inserted as SQL VALUES literals (appear in QUERY_HISTORY)
+- All bulk inserts use `session.write_pandas()` → COPY INTO (data not in query history)
+- Private Mode: response not logged (NULL in RESPONSE column), shown with 🔒
+- KEYWORD insights use `SHA2(PROMPT)` hash — only hash in Python, not prompt text
+
+## Scale Design (50K users)
+- `CC_PROMPT_EVENTS` clustered by `EVENT_DATE` — micro-partition pruning on all date queries
+- All dashboard queries hit `CC_USAGE_DAILY_SUMMARY` (small aggregated) — never raw events
+- Prompt Browser: mandatory date filter + hard LIMIT 5,000
+- KEYWORD classification: SQL `FLATTEN + CONTAINS` (Snowflake-parallel, not Python loops)
+- Category classification: 5K prompts/night cap, QUALIFY dedup by prompt hash
+
+## Nightly Task Schedule
+| Task | Schedule |
+|---|---|
+| `CC_REFRESH_USAGE_SUMMARIES` | Every 30 min |
+| `CC_CLASSIFY_PROMPTS_TASK` | 2am UTC |
+| `CC_DAILY_RESET_LIMITS` | Midnight UTC (only if credit limits configured) |
+| `CC_ALERT_CHECK` | Every 5 min |
+| `CC_REALTIME_VIOLATION_ALERT` | Every 1 min (stream-based, HIGH severity only) |
+
+## Roles
+| Role | Purpose |
+|---|---|
+| `CC_SP_OWNER_ROLE` | Owns all SPs. Has MANAGE GRANTS + ALTER USER. Never assumed by humans. |
+| `CC_APP_ROLE` | Streamlit runtime. Can read/write CC_* tables and CALL all SPs. |
+| `CC_ADMIN_ROLE` | Human admins. Has CC_APP_ROLE. Sees all pages. |
+| `CC_USER_ROLE` | End users. Has CC_APP_ROLE. Sees Home + Credit Requests only. |
+
+Admin page access controlled by `admin.roles` in `config.yaml`.
+
+---
+
+## Cortex AI Guardrails
+
+Platform-level protection (Snowflake Horizon Catalog, Enterprise Edition) against prompt injection and jailbreak attacks on Cortex Code, Cortex Agents, and Snowflake Intelligence.
+
+- **Where shown:** Home page metric card ("AI Guardrails"), AI Observability headline expander (auto-expands when disabled)
+- **Detection:** `SHOW PARAMETERS LIKE 'AI_SETTINGS' IN ACCOUNT` — checks for `enabled: true` in the YAML value
+- **Enable SQL:** `ALTER ACCOUNT SET AI_SETTINGS = $$ guardrails: advanced_prompt_injection: - enabled: true $$;`
+- **Requires:** Enterprise Edition + `CORTEX_ENABLED_CROSS_REGION = 'ANY'`
+- **Cost:** Billed per token scanned (see Service Consumption Table)
+- **Setup:** Setup page → Account Prerequisites → Step 6
+
+---
+
+## Native AI Budgets (Snowflake Preview)
+
+Tag-based hard enforcement for Cortex Agent objects. Automates REVOKE USAGE when monthly spend reaches 100% of the configured limit.
+
+- **How it differs from CoCo credit management:** CoCo = soft per-user daily limits (governance layer). Native Budgets = hard monthly cap on Cortex Agent objects (enforcement layer).
+- **Scope:** Cortex Agent objects only — NOT general Cortex Code CLI/Snowsight usage
+- **Enforcement lag:** Up to 8 hours standard, ~2 hours with low-latency option
+- **Where shown:** Credit Configuration page → Native AI Budgets expander; Setup → Account Prerequisites → Step 7
+- **Setup flow:** Create tag → apply to agent → create SNOWFLAKE.CORE.BUDGET → SET_SPENDING_LIMIT → SET_NOTIFICATION_THRESHOLD
+
+---
+
+## Cache Hit Rate Formula
+
+**Correct formula:** `cache_read / (cache_read + cache_write)` × 100
+
+- `cache_read` = tokens served from cache (hit) — charged at 0.1× base
+- `cache_write` = tokens written to cache for first time (miss) — charged at 1.25× base
+- `input_tokens` = fresh uncached tokens — NOT part of the cache system, excluded from formula
+- This is the standard hits/(hits+misses) ratio used in all Deloitte/McKinsey observability frameworks
+- **GPT models showing 100%:** If `cache_write = 0`, formula gives 100% — this is a data reporting artifact (GPT may not report write tokens separately), not a true hit rate
+
+**Previous wrong formula (now fixed):** `cache_read / (cache_read + input)` — was diluting the ratio by including unrelated input tokens.
+
+---
+
+## Terminology Guide (Enterprise-Friendly)
+
+| Old term | New term | Why |
+|---|---|---|
+| Violations | Prompt Insights | Governance framing, not punitive |
+| Violation Rate | Insight Rate | Same |
+| Risk Dashboard | Governance Dashboard | Deloitte/Bain standard |
+| Risk Profile | Governance Profile | Same |
+| High/Medium/Low Risk | High/Medium/Low Severity | Standard ITSM/SOC language |
+| LLM-as-Judge Evaluation | Custom Quality (Experimental) | Honest about limitations |
+
+---
+
+## Account Prerequisites (Setup Page — 7 Steps)
+
+Before running Phases A–E, admins must run these one-time account-level grants:
+
+1. **Cross-Region Inference** — `ALTER ACCOUNT SET CORTEX_ENABLED_CROSS_REGION = 'ANY'`
+2. **AI Observability Access** — `GRANT DATABASE ROLE SNOWFLAKE.AI_OBSERVABILITY_READER TO ROLE CC_SP_OWNER_ROLE`
+3. **ACCOUNT_USAGE Access** — `GRANT IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE TO ROLE CC_SP_OWNER_ROLE`
+4. **Model Access for Users** — `GRANT DATABASE ROLE SNOWFLAKE.CORTEX_USER TO ROLE CC_USER_ROLE`
+5. **Credit Limits** _(optional)_ — `ALTER ACCOUNT SET CORTEX_CODE_CREDIT_LIMIT = N`
+6. **AI Guardrails** _(optional, Enterprise)_ — `ALTER ACCOUNT SET AI_SETTINGS = $$ guardrails: ... $$`
+7. **Native AI Budgets** _(optional, Preview)_ — tag-based budget enforcement
+
+Setup page shows copy-paste SQL for each. Status chips show ✓ green (done) / ⚠ amber (not yet configured). Red only for explicitly wrong values.
+
+---
+
+## config.yaml Defaults
+
+```yaml
+deployment:
+  database: ""    # Leave blank → uses CURRENT_DATABASE()
+  schema: ""      # Leave blank → uses CURRENT_SCHEMA()
+
+admin:
+  roles:
+    - ACCOUNTADMIN
+    # Add customer's own admin role here
+```
+
+Never hardcode YOUR_DB or YOUR_SCHEMA — those are the developer's personal account values.
+
+
+---
+
+## Known Data Behaviours
+
+| Observation | Explanation |
+|---|---|
+| Sessions show as "Surface Unknown" / blank | `origin_application` is used as the primary surface lookup (always populated with `snowsight`, `cortex-code-cli`, or `snowflake_coco_desktop`). Old rows stored `ENTRYPOINT = ''` (empty string) before the fix — empty strings bypass `IS NOT NULL` filters. Fix: Phase C (recreate SP) + truncate `CC_PROMPT_EVENTS` + Phase D2 re-backfill 180 days. |
+| Desktop Sessions = 0 even after fix | Run Phase C (recreate SP) then Phase D2 (re-backfill). Pages read from CC_PROMPT_EVENTS — no page code changes needed. |
+| GPT models show 100% cache hit rate | OpenAI does not report `cache_write` tokens. Formula `cache_read / (cache_read + 0) = 100%` — treat as "cache write data unavailable", not a true hit rate. |
+| Prompt Intelligence numbers unchanged across periods | `CC_PROMPT_EVENTS` only holds data for periods the SP was run. If backfill covers only 30 days and all events fall within 7 days, selecting 7 / 14 / 30 returns the same count. Run D2 with a larger window to fill gaps. |
+| Desktop Sessions = 0 | Expected if no users are running Cortex Code Desktop in this account. CLI and Snowsight are the primary surfaces. |
+
+---
+
+## ENTRYPOINT / Surface Detection
+
+Surface (CLI / SNOWSIGHT / DESKTOP) comes from the `CodingAgentRun` span in `AI_OBSERVABILITY_EVENTS`:
+
+```sql
+-- Primary field (populated for CLI/Desktop)
+snow.ai.observability.agent.coding_agent.entrypoint  -> CLI / DESKTOP
+
+-- Fallback for Snowsight (entrypoint is NULL but client_type is set)
+snow.ai.observability.agent.coding_agent.client_type
+  codingagent_snowsight   -> SNOWSIGHT
+  codingagent_snova       -> CLI
+  codingagent_desktop     -> DESKTOP  (legacy)
+  snowflake_coco_desktop  -> DESKTOP  (actual Desktop client_type as confirmed from enterprise accounts)
+```
+
+The SP uses `COALESCE(entrypoint, CASE client_type ...)` to handle both cases.
+Requires Phase C re-run to take effect in new deployments.
+
+---
+
+## Deploying Updates — What to Re-Run
+
+After a code-only deploy (`snow streamlit deploy --replace`):
+
+| Changed | Re-run needed |
+|---|---|
+| `sp_definitions.py` | Phase C (recreate SPs) + Phase D2 (re-backfill if needed) |
+| `pages/*.py` only | None — takes effect on page reload |
+| `config.yaml` admin roles | None — read at runtime |
+| `prerequisites.sql` | Phase A only if new tables added |
+
+
+---
+
+## Desktop Surface — Complete Fix Record
+
+Desktop (`snowflake_coco_desktop`) was missing from multiple components. All gaps fixed in this release:
+
+### What was missing
+
+| Component | Gap | Fix |
+|---|---|---|
+| `CC_CREDIT_CONFIG` table | No `DESKTOP_DAILY_LIMIT` column | Added |
+| `CC_USAGE_DAILY_SUMMARY` table | No `DESKTOP_LIMIT_AT_DATE` column | Added |
+| `SP_CC_REFRESH_USAGE_SUMMARIES` | No `CORTEX_CODE_DESKTOP_USAGE_HISTORY` MERGE | Added (daily + hourly) |
+| `SP_CC_DAILY_RESET_LIMITS` | Only reset CLI + Snowsight at midnight | Now resets Desktop too |
+| `credit_config.py _apply_cohort` | Silently dropped Desktop limit | Now saves `DESKTOP_DAILY_LIMIT` |
+| `credit_config.py` user override | Same | Fixed |
+| `observability.py` cohort credits | No `DT_CREDITS` surface split | Added |
+| `observability.py` user detail | Only CLI + Snowsight metrics | Added Desktop Credits card |
+| `cost_attribution.py` cohort summary | No `COHORT_DT_LIMIT` | Added |
+
+Already correct: all other SPs (rebalance, bulk set/grant, expire), `config.py SURFACES`, `home.py`, `usage_trends.py`.
+
+### ENTRYPOINT empty-string bug (also fixed)
+
+SP was using `fillna("")` which stored `""` not `NULL` for unresolved sessions. Empty strings bypass `IS NOT NULL` filters, appearing as a blank row in charts. Fixed: SP stores `None`; query adds `AND ENTRYPOINT != ""`.
+
+### Deployment sequence for a fresh install
+
+After deploying updated code (`snow streamlit deploy --replace`):
+
+1. **Account Prerequisites** — 7 SQL blocks in Snowsight as ACCOUNTADMIN
+2. **Phase A** — recreates all objects including new Desktop columns
+3. **Phase B** — seed defaults
+4. **Phase C** — recreates `SP_CC_CLASSIFY_PROMPTS` with `origin_application`-first ENTRYPOINT
+5. **`TRUNCATE CC_PROMPT_EVENTS`** — resets watermark for full re-backfill
+6. **Phase D1** — backfill credits (now includes Desktop via `CORTEX_CODE_DESKTOP_USAGE_HISTORY`)
+7. **Phase D2 / 180 days** — re-classify all prompts with correct surface (`CALL SP_CC_CLASSIFY_PROMPTS(4320)`)
+8. **Phase E** — verify all objects


### PR DESCRIPTION
## Summary

Adds the two Cortex Code CLI skill docs to the `cortex-code-control-hub` quickstart assets.

- `assets/code/skills/coco-hub-deploy/SKILL.md` — deployment guide skill
- `assets/code/skills/coco-hub-knowledge/SKILL.md` — app knowledge base skill

These were omitted from the original PR (#3354) and are needed for users who want to use the Cortex Code CLI skills alongside the app.

## Test plan
- [ ] Files appear at the correct path under `assets/code/skills/`
- [ ] No personal identifiers in skill docs

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
