### PR TITLE
CASEC-10663: fix PWN request via pull_request_target

### DIFF
--- a/.github/workflows/stage-to-aem.yml
+++ b/.github/workflows/stage-to-aem.yml
@@ -19,6 +19,10 @@ on:
         description: 'PR number for commenting'
         required: true
         type: number
+      base_sha:
+        description: 'Base branch SHA for trusted script checkout (security: prevents attacker-controlled scripts from running with secrets)'
+        required: true
+        type: string
       source_path:
         description: 'Path to the source folder containing the markdown'
         required: false
@@ -58,14 +62,22 @@ jobs:
       AEM_URL: ${{ secrets.AEM_AUTHOR_URL }}
       AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL }}
     steps:
-      - name: Checkout repository
+      - name: Checkout PR content (markdown and assets only)
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit_sha }}
           sparse-checkout: |
             ${{ inputs.source_path || format('site/sfguides/src/{0}', inputs.quickstart_name) }}
+          sparse-checkout-cone-mode: true
+
+      - name: Checkout trusted scripts (from base branch)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_sha }}
+          sparse-checkout: |
             scripts/aem-staging
           sparse-checkout-cone-mode: true
+          path: trusted-scripts
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -95,7 +107,7 @@ jobs:
           QUICKSTART_NAME: ${{ inputs.quickstart_name }}
           BASE_IMAGE_URL: "https://raw.githubusercontent.com/${{ github.repository }}/${{ inputs.commit_sha }}/site/sfguides/src"
         run: |
-          python3 scripts/aem-staging/parse_markdown.py \
+          python3 trusted-scripts/scripts/aem-staging/parse_markdown.py \
             "${{ steps.find_md.outputs.md_file }}" \
             --commit-sha "$COMMIT_SHA" \
             --quickstart-name "$QUICKSTART_NAME" \
@@ -113,7 +125,7 @@ jobs:
           cf_name="${{ inputs.quickstart_name }}-${{ inputs.commit_sha }}"
           cf_path="${CF_DEST_PATH}/${LANGUAGE}/content-fragments/quickstarts/${cf_name}"
           
-          python3 scripts/aem-staging/prepare_aem_payload.py \
+          python3 trusted-scripts/scripts/aem-staging/prepare_aem_payload.py \
             parsed_content.json \
             --content-fragment-path "$cf_path" \
             --language "$LANGUAGE" \

--- a/.github/workflows/validate-and-stage_no_workato.yml
+++ b/.github/workflows/validate-and-stage_no_workato.yml
@@ -671,7 +671,9 @@ jobs:
       quickstart_name: ${{ matrix.quickstart.name }}
       language: ${{ matrix.quickstart.language || 'en' }}
       commit_sha: ${{ github.event.pull_request.head.sha }}
+      base_sha: ${{ github.event.pull_request.base.sha }}
       pr_number: ${{ github.event.pull_request.number }}
+      source_path: ${{ matrix.guide.source_path }}
     secrets:
       AEM_USERNAME: ${{ secrets.AEM_USERNAME_STAGING }}
       AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_STAGING }}
@@ -689,14 +691,22 @@ jobs:
       AEM_USERNAME: ${{ secrets.AEM_USERNAME_STAGING }}
       AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_STAGING }}
     steps:
-      - name: Checkout repository
+      - name: Checkout PR content (journeys)
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           sparse-checkout: |
             journeys/
+          sparse-checkout-cone-mode: true
+
+      - name: Checkout trusted script (from base branch)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
             scripts/upload-dam-asset.sh
           sparse-checkout-cone-mode: true
+          path: trusted-scripts
 
       - name: Create DAM folder if needed
         run: |
@@ -741,7 +751,7 @@ jobs:
             [ -z "$file" ] && continue
             [ -f "$file" ] || continue
             echo "📤 Uploading sidebar JSON: $file"
-            bash scripts/upload-dam-asset.sh "$file" "snowflake-site/developers/technical/guides-navigation"
+            bash trusted-scripts/scripts/upload-dam-asset.sh "$file" "snowflake-site/developers/technical/guides-navigation"
           done
           echo "✅ Sidebar JSON upload complete"
 
@@ -758,8 +768,8 @@ jobs:
       quickstart_name: ${{ matrix.guide.name }}
       language: en
       commit_sha: ${{ github.event.pull_request.head.sha }}
+      base_sha: ${{ github.event.pull_request.base.sha }}
       pr_number: ${{ github.event.pull_request.number }}
-      source_path: ${{ matrix.guide.source_path }}
       page_base_path: /content/snowflake-site/global/en/developers/guides/journey-sidebar-base
     secrets:
       AEM_USERNAME: ${{ secrets.AEM_USERNAME_STAGING }}


### PR DESCRIPTION
Split script checkout from content checkout in stage-to-aem.yml and upload_sidebar_json job. Trusted scripts are now checked out from the base branch SHA, not the PR head SHA, preventing attackers from exfiltrating AEM credentials via modified scripts in fork PRs.