### PR TITLE
[ETCE-13205]: switch AEM credentials from GitHub secrets to AWS Secrets Manag…

### DIFF
--- a/.github/workflows/publish-on-approval_no_workato.yml
+++ b/.github/workflows/publish-on-approval_no_workato.yml
@@ -150,14 +150,53 @@ jobs:
           relevant_changed_files_json=$(echo "$relevant_files" | jq -R -s -c 'split("\n") | map(select(length>0))')
           echo "relevant_changed_files_json=$relevant_changed_files_json" >> $GITHUB_OUTPUT
 
+  fetch_prod_secrets:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      aem_username:    ${{ steps.secrets.outputs.aem_username }}
+      aem_password:    ${{ steps.secrets.outputs.aem_password }}
+      aem_author_url:  ${{ steps.secrets.outputs.aem_author_url }}
+      aem_publish_url: ${{ steps.secrets.outputs.aem_publish_url }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::418643147302:role/github-snowflake-labs-aem-iam-role
+          aws-region: us-west-1
+
+      - name: Fetch AEM prod secrets
+        id: secrets
+        run: |
+          secret=$(aws secretsmanager get-secret-value \
+            --secret-id github-snowflake-labs-aem-prod-secrets \
+            --query SecretString --output text)
+
+          aem_username=$(echo "$secret" | jq -r '.AEM_USERNAME')
+          aem_password=$(echo "$secret" | jq -r '.AEM_PASSWORD')
+          aem_author_url=$(echo "$secret" | jq -r '.AEM_AUTHOR_URL')
+          aem_publish_url=$(echo "$secret" | jq -r '.AEM_PUBLISH_URL')
+
+          echo "::add-mask::$aem_username"
+          echo "::add-mask::$aem_password"
+          echo "::add-mask::$aem_author_url"
+          echo "::add-mask::$aem_publish_url"
+
+          echo "aem_username=$aem_username" >> $GITHUB_OUTPUT
+          echo "aem_password=$aem_password" >> $GITHUB_OUTPUT
+          echo "aem_author_url=$aem_author_url" >> $GITHUB_OUTPUT
+          echo "aem_publish_url=$aem_publish_url" >> $GITHUB_OUTPUT
+
   upload_sidebar_json:
-    needs: detect_changes
+    needs: [detect_changes, fetch_prod_secrets]
     if: needs.detect_changes.outputs.has_sidebar_changes == 'true'
     runs-on: ubuntu-latest
     env:
-      AEM_URL: ${{ secrets.AEM_AUTHOR_URL_PROD }}
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME_PROD }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_PROD }}
+      AEM_URL: ${{ needs.fetch_prod_secrets.outputs.aem_author_url }}
+      AEM_USERNAME: ${{ needs.fetch_prod_secrets.outputs.aem_username }}
+      AEM_PASSWORD: ${{ needs.fetch_prod_secrets.outputs.aem_password }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -234,7 +273,7 @@ jobs:
           echo "✅ Sidebar JSON publish complete"
 
   publish_to_aem:
-    needs: detect_changes
+    needs: [detect_changes, fetch_prod_secrets]
     if: |
       needs.detect_changes.outputs.has_relevant_changes == 'true' &&
       needs.detect_changes.outputs.quickstart_names_json != '[]'
@@ -250,13 +289,13 @@ jobs:
       commit_sha: ${{ github.sha }}
       base_image_url: ${{ vars.AEM_BASE_IMAGE_URL }}
     secrets:
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME_PROD }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_PROD }}
-      AEM_AUTHOR_URL: ${{ secrets.AEM_AUTHOR_URL_PROD }}
-      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL_PROD }}
+      AEM_USERNAME: ${{ needs.fetch_prod_secrets.outputs.aem_username }}
+      AEM_PASSWORD: ${{ needs.fetch_prod_secrets.outputs.aem_password }}
+      AEM_AUTHOR_URL: ${{ needs.fetch_prod_secrets.outputs.aem_author_url }}
+      AEM_PUBLISH_URL: ${{ needs.fetch_prod_secrets.outputs.aem_publish_url }}
 
   publish_journey_guides:
-    needs: detect_changes
+    needs: [detect_changes, fetch_prod_secrets]
     if: needs.detect_changes.outputs.has_journey_guides == 'true'
     strategy:
       matrix:
@@ -272,7 +311,7 @@ jobs:
       source_path: ${{ matrix.guide.source_path }}
       page_base_path: /content/snowflake-site/global/en/developers/guides/journey-sidebar-base
     secrets:
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME_PROD }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_PROD }}
-      AEM_AUTHOR_URL: ${{ secrets.AEM_AUTHOR_URL_PROD }}
-      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL_PROD }}
+      AEM_USERNAME: ${{ needs.fetch_prod_secrets.outputs.aem_username }}
+      AEM_PASSWORD: ${{ needs.fetch_prod_secrets.outputs.aem_password }}
+      AEM_AUTHOR_URL: ${{ needs.fetch_prod_secrets.outputs.aem_author_url }}
+      AEM_PUBLISH_URL: ${{ needs.fetch_prod_secrets.outputs.aem_publish_url }}

--- a/.github/workflows/validate-and-stage_no_workato.yml
+++ b/.github/workflows/validate-and-stage_no_workato.yml
@@ -660,8 +660,47 @@ jobs:
           
           echo "quickstart_names_json=$objs" >> $GITHUB_OUTPUT
 
+  fetch_staging_secrets:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      aem_username:    ${{ steps.secrets.outputs.aem_username }}
+      aem_password:    ${{ steps.secrets.outputs.aem_password }}
+      aem_author_url:  ${{ steps.secrets.outputs.aem_author_url }}
+      aem_publish_url: ${{ steps.secrets.outputs.aem_publish_url }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::418643147302:role/github-snowflake-labs-aem-iam-role
+          aws-region: us-west-1
+
+      - name: Fetch AEM staging secrets
+        id: secrets
+        run: |
+          secret=$(aws secretsmanager get-secret-value \
+            --secret-id github-snowflake-labs-aem-staging-secrets \
+            --query SecretString --output text)
+
+          aem_username=$(echo "$secret" | jq -r '.AEM_USERNAME')
+          aem_password=$(echo "$secret" | jq -r '.AEM_PASSWORD')
+          aem_author_url=$(echo "$secret" | jq -r '.AEM_AUTHOR_URL')
+          aem_publish_url=$(echo "$secret" | jq -r '.AEM_PUBLISH_URL')
+
+          echo "::add-mask::$aem_username"
+          echo "::add-mask::$aem_password"
+          echo "::add-mask::$aem_author_url"
+          echo "::add-mask::$aem_publish_url"
+
+          echo "aem_username=$aem_username" >> $GITHUB_OUTPUT
+          echo "aem_password=$aem_password" >> $GITHUB_OUTPUT
+          echo "aem_author_url=$aem_author_url" >> $GITHUB_OUTPUT
+          echo "aem_publish_url=$aem_publish_url" >> $GITHUB_OUTPUT
+
   stage_to_aem:
-    needs: validate_and_stage_no_workato
+    needs: [validate_and_stage_no_workato, fetch_staging_secrets]
     if: |
       needs.validate_and_stage_no_workato.outputs.has_relevant_changes == 'true' && 
       needs.validate_and_stage_no_workato.outputs.all_validations_passed == 'true' &&
@@ -681,21 +720,21 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       source_path: ${{ matrix.guide.source_path }}
     secrets:
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME_STAGING }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_STAGING }}
-      AEM_AUTHOR_URL: ${{ secrets.AEM_AUTHOR_URL_STAGING }}
-      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL_STAGING }}
+      AEM_USERNAME: ${{ needs.fetch_staging_secrets.outputs.aem_username }}
+      AEM_PASSWORD: ${{ needs.fetch_staging_secrets.outputs.aem_password }}
+      AEM_AUTHOR_URL: ${{ needs.fetch_staging_secrets.outputs.aem_author_url }}
+      AEM_PUBLISH_URL: ${{ needs.fetch_staging_secrets.outputs.aem_publish_url }}
 
   upload_sidebar_json:
-    needs: validate_and_stage_no_workato
+    needs: [validate_and_stage_no_workato, fetch_staging_secrets]
     if: needs.validate_and_stage_no_workato.outputs.has_sidebar_changes == 'true'
     runs-on: ubuntu-latest
     environment:
       name: staging
     env:
-      AEM_URL: ${{ secrets.AEM_AUTHOR_URL_STAGING }}
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME_STAGING }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_STAGING }}
+      AEM_URL: ${{ needs.fetch_staging_secrets.outputs.aem_author_url }}
+      AEM_USERNAME: ${{ needs.fetch_staging_secrets.outputs.aem_username }}
+      AEM_PASSWORD: ${{ needs.fetch_staging_secrets.outputs.aem_password }}
     steps:
       - name: Checkout PR content (journeys)
         uses: actions/checkout@v4
@@ -762,7 +801,7 @@ jobs:
           echo "✅ Sidebar JSON upload complete"
 
   stage_journey_guides:
-    needs: validate_and_stage_no_workato
+    needs: [validate_and_stage_no_workato, fetch_staging_secrets]
     if: needs.validate_and_stage_no_workato.outputs.has_journey_guides == 'true'
     strategy:
       matrix:
@@ -778,7 +817,7 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       page_base_path: /content/snowflake-site/global/en/developers/guides/journey-sidebar-base
     secrets:
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME_STAGING }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_STAGING }}
-      AEM_AUTHOR_URL: ${{ secrets.AEM_AUTHOR_URL_STAGING }}
-      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL_STAGING }}
+      AEM_USERNAME: ${{ needs.fetch_staging_secrets.outputs.aem_username }}
+      AEM_PASSWORD: ${{ needs.fetch_staging_secrets.outputs.aem_password }}
+      AEM_AUTHOR_URL: ${{ needs.fetch_staging_secrets.outputs.aem_author_url }}
+      AEM_PUBLISH_URL: ${{ needs.fetch_staging_secrets.outputs.aem_publish_url }}


### PR DESCRIPTION
…er via OIDC

Replace hardcoded GitHub Actions secrets (AEM_USERNAME_PROD/STAGING etc.) with AWS Secrets Manager fetched via GitHub OIDC. Adds fetch_prod_secrets and fetch_staging_secrets jobs that assume the github-snowflake-labs-aem-iam-role IAM role and pull credentials from github-snowflake-labs-aem-{prod,staging}-secrets.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)