### PR TITLE
fix: move OIDC+Secrets Manager fetch into reusable workflows

### DIFF
--- a/.github/workflows/publish-on-approval_no_workato.yml
+++ b/.github/workflows/publish-on-approval_no_workato.yml
@@ -150,16 +150,13 @@ jobs:
           relevant_changed_files_json=$(echo "$relevant_files" | jq -R -s -c 'split("\n") | map(select(length>0))')
           echo "relevant_changed_files_json=$relevant_changed_files_json" >> $GITHUB_OUTPUT
 
-  fetch_prod_secrets:
+  upload_sidebar_json:
+    needs: detect_changes
+    if: needs.detect_changes.outputs.has_sidebar_changes == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
-    outputs:
-      aem_username:    ${{ steps.secrets.outputs.aem_username }}
-      aem_password:    ${{ steps.secrets.outputs.aem_password }}
-      aem_author_url:  ${{ steps.secrets.outputs.aem_author_url }}
-      aem_publish_url: ${{ steps.secrets.outputs.aem_publish_url }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -168,7 +165,6 @@ jobs:
           aws-region: us-west-1
 
       - name: Fetch AEM prod secrets
-        id: secrets
         run: |
           secret=$(aws secretsmanager get-secret-value \
             --secret-id github-snowflake-labs-aem-prod-secrets \
@@ -177,27 +173,14 @@ jobs:
           aem_username=$(echo "$secret" | jq -r '.AEM_USERNAME')
           aem_password=$(echo "$secret" | jq -r '.AEM_PASSWORD')
           aem_author_url=$(echo "$secret" | jq -r '.AEM_AUTHOR_URL')
-          aem_publish_url=$(echo "$secret" | jq -r '.AEM_PUBLISH_URL')
 
           echo "::add-mask::$aem_username"
           echo "::add-mask::$aem_password"
-          echo "::add-mask::$aem_author_url"
-          echo "::add-mask::$aem_publish_url"
 
-          echo "aem_username=$aem_username" >> $GITHUB_OUTPUT
-          echo "aem_password=$aem_password" >> $GITHUB_OUTPUT
-          echo "aem_author_url=$aem_author_url" >> $GITHUB_OUTPUT
-          echo "aem_publish_url=$aem_publish_url" >> $GITHUB_OUTPUT
+          echo "AEM_URL=$aem_author_url" >> $GITHUB_ENV
+          echo "AEM_USERNAME=$aem_username" >> $GITHUB_ENV
+          echo "AEM_PASSWORD=$aem_password" >> $GITHUB_ENV
 
-  upload_sidebar_json:
-    needs: [detect_changes, fetch_prod_secrets]
-    if: needs.detect_changes.outputs.has_sidebar_changes == 'true'
-    runs-on: ubuntu-latest
-    env:
-      AEM_URL: ${{ needs.fetch_prod_secrets.outputs.aem_author_url }}
-      AEM_USERNAME: ${{ needs.fetch_prod_secrets.outputs.aem_username }}
-      AEM_PASSWORD: ${{ needs.fetch_prod_secrets.outputs.aem_password }}
-    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -273,7 +256,7 @@ jobs:
           echo "✅ Sidebar JSON publish complete"
 
   publish_to_aem:
-    needs: [detect_changes, fetch_prod_secrets]
+    needs: detect_changes
     if: |
       needs.detect_changes.outputs.has_relevant_changes == 'true' &&
       needs.detect_changes.outputs.quickstart_names_json != '[]'
@@ -288,14 +271,10 @@ jobs:
       language: ${{ matrix.quickstart.language || 'en' }}
       commit_sha: ${{ github.sha }}
       base_image_url: ${{ vars.AEM_BASE_IMAGE_URL }}
-    secrets:
-      AEM_USERNAME: ${{ needs.fetch_prod_secrets.outputs.aem_username }}
-      AEM_PASSWORD: ${{ needs.fetch_prod_secrets.outputs.aem_password }}
-      AEM_AUTHOR_URL: ${{ needs.fetch_prod_secrets.outputs.aem_author_url }}
-      AEM_PUBLISH_URL: ${{ needs.fetch_prod_secrets.outputs.aem_publish_url }}
+      aws_secret_name: github-snowflake-labs-aem-prod-secrets
 
   publish_journey_guides:
-    needs: [detect_changes, fetch_prod_secrets]
+    needs: detect_changes
     if: needs.detect_changes.outputs.has_journey_guides == 'true'
     strategy:
       matrix:
@@ -310,8 +289,4 @@ jobs:
       base_image_url: ${{ vars.AEM_BASE_IMAGE_URL }}
       source_path: ${{ matrix.guide.source_path }}
       page_base_path: /content/snowflake-site/global/en/developers/guides/journey-sidebar-base
-    secrets:
-      AEM_USERNAME: ${{ needs.fetch_prod_secrets.outputs.aem_username }}
-      AEM_PASSWORD: ${{ needs.fetch_prod_secrets.outputs.aem_password }}
-      AEM_AUTHOR_URL: ${{ needs.fetch_prod_secrets.outputs.aem_author_url }}
-      AEM_PUBLISH_URL: ${{ needs.fetch_prod_secrets.outputs.aem_publish_url }}
+      aws_secret_name: github-snowflake-labs-aem-prod-secrets

--- a/.github/workflows/publish-to-aem.yml
+++ b/.github/workflows/publish-to-aem.yml
@@ -29,19 +29,10 @@ on:
         required: false
         type: string
         default: ''
-    secrets:
-      AEM_USERNAME:
-        description: 'AEM username for basic auth'
+      aws_secret_name:
+        description: 'AWS Secrets Manager secret name containing AEM credentials'
         required: true
-      AEM_PASSWORD:
-        description: 'AEM password for basic auth'
-        required: true
-      AEM_AUTHOR_URL:
-        description: 'AEM author instance URL'
-        required: true
-      AEM_PUBLISH_URL:
-        description: 'AEM publish instance URL'
-        required: true
+        type: string
 
 env:
   BASE_CF_PATH: /content/dam/snowflake-site/en/content-fragments/base-fragments/base-quickstart-cf
@@ -52,14 +43,38 @@ env:
 jobs:
   publish_quickstart:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD }}
-      AEM_URL: ${{ secrets.AEM_AUTHOR_URL }}
-      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL }}
       MAX_RETRIES: 3
       RETRY_DELAY: 5
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::886692307588:role/github-snowflake-labs-aem-iam-role
+          aws-region: us-west-1
+
+      - name: Fetch AEM secrets
+        run: |
+          secret=$(aws secretsmanager get-secret-value \
+            --secret-id "${{ inputs.aws_secret_name }}" \
+            --query SecretString --output text)
+
+          aem_username=$(echo "$secret" | jq -r '.AEM_USERNAME')
+          aem_password=$(echo "$secret" | jq -r '.AEM_PASSWORD')
+          aem_author_url=$(echo "$secret" | jq -r '.AEM_AUTHOR_URL')
+          aem_publish_url=$(echo "$secret" | jq -r '.AEM_PUBLISH_URL')
+
+          echo "::add-mask::$aem_username"
+          echo "::add-mask::$aem_password"
+
+          echo "AEM_USERNAME=$aem_username" >> $GITHUB_ENV
+          echo "AEM_PASSWORD=$aem_password" >> $GITHUB_ENV
+          echo "AEM_URL=$aem_author_url" >> $GITHUB_ENV
+          echo "AEM_PUBLISH_URL=$aem_publish_url" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/stage-to-aem.yml
+++ b/.github/workflows/stage-to-aem.yml
@@ -33,19 +33,10 @@ on:
         required: false
         type: string
         default: ''
-    secrets:
-      AEM_USERNAME:
-        description: 'AEM username for basic auth'
+      aws_secret_name:
+        description: 'AWS Secrets Manager secret name containing AEM credentials'
         required: true
-      AEM_PASSWORD:
-        description: 'AEM password for basic auth'
-        required: true
-      AEM_AUTHOR_URL:
-        description: 'AEM author instance URL'
-        required: true
-      AEM_PUBLISH_URL:
-        description: 'AEM publish instance URL'
-        required: true
+        type: string
 
 env:
   BASE_CF_PATH: /content/dam/snowflake-site/en/content-fragments/base-fragments/base-quickstart-cf
@@ -56,12 +47,38 @@ env:
 jobs:
   stage_quickstart:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD }}
-      AEM_URL: ${{ secrets.AEM_AUTHOR_URL }}
-      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL }}
+      MAX_RETRIES: 3
+      RETRY_DELAY: 5
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::886692307588:role/github-snowflake-labs-aem-iam-role
+          aws-region: us-west-1
+
+      - name: Fetch AEM secrets
+        run: |
+          secret=$(aws secretsmanager get-secret-value \
+            --secret-id "${{ inputs.aws_secret_name }}" \
+            --query SecretString --output text)
+
+          aem_username=$(echo "$secret" | jq -r '.AEM_USERNAME')
+          aem_password=$(echo "$secret" | jq -r '.AEM_PASSWORD')
+          aem_author_url=$(echo "$secret" | jq -r '.AEM_AUTHOR_URL')
+          aem_publish_url=$(echo "$secret" | jq -r '.AEM_PUBLISH_URL')
+
+          echo "::add-mask::$aem_username"
+          echo "::add-mask::$aem_password"
+
+          echo "AEM_USERNAME=$aem_username" >> $GITHUB_ENV
+          echo "AEM_PASSWORD=$aem_password" >> $GITHUB_ENV
+          echo "AEM_URL=$aem_author_url" >> $GITHUB_ENV
+          echo "AEM_PUBLISH_URL=$aem_publish_url" >> $GITHUB_ENV
+
       - name: Checkout PR content (markdown and assets only)
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/validate-and-stage_no_workato.yml
+++ b/.github/workflows/validate-and-stage_no_workato.yml
@@ -660,47 +660,8 @@ jobs:
           
           echo "quickstart_names_json=$objs" >> $GITHUB_OUTPUT
 
-  fetch_staging_secrets:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    outputs:
-      aem_username:    ${{ steps.secrets.outputs.aem_username }}
-      aem_password:    ${{ steps.secrets.outputs.aem_password }}
-      aem_author_url:  ${{ steps.secrets.outputs.aem_author_url }}
-      aem_publish_url: ${{ steps.secrets.outputs.aem_publish_url }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::886692307588:role/github-snowflake-labs-aem-iam-role
-          aws-region: us-west-1
-
-      - name: Fetch AEM staging secrets
-        id: secrets
-        run: |
-          secret=$(aws secretsmanager get-secret-value \
-            --secret-id github-snowflake-labs-aem-staging-secrets \
-            --query SecretString --output text)
-
-          aem_username=$(echo "$secret" | jq -r '.AEM_USERNAME')
-          aem_password=$(echo "$secret" | jq -r '.AEM_PASSWORD')
-          aem_author_url=$(echo "$secret" | jq -r '.AEM_AUTHOR_URL')
-          aem_publish_url=$(echo "$secret" | jq -r '.AEM_PUBLISH_URL')
-
-          echo "::add-mask::$aem_username"
-          echo "::add-mask::$aem_password"
-          echo "::add-mask::$aem_author_url"
-          echo "::add-mask::$aem_publish_url"
-
-          echo "aem_username=$aem_username" >> $GITHUB_OUTPUT
-          echo "aem_password=$aem_password" >> $GITHUB_OUTPUT
-          echo "aem_author_url=$aem_author_url" >> $GITHUB_OUTPUT
-          echo "aem_publish_url=$aem_publish_url" >> $GITHUB_OUTPUT
-
   stage_to_aem:
-    needs: [validate_and_stage_no_workato, fetch_staging_secrets]
+    needs: validate_and_stage_no_workato
     if: |
       needs.validate_and_stage_no_workato.outputs.has_relevant_changes == 'true' && 
       needs.validate_and_stage_no_workato.outputs.all_validations_passed == 'true' &&
@@ -719,23 +680,41 @@ jobs:
       base_sha: ${{ github.event.pull_request.base.sha }}
       pr_number: ${{ github.event.pull_request.number }}
       source_path: ${{ matrix.guide.source_path }}
-    secrets:
-      AEM_USERNAME: ${{ needs.fetch_staging_secrets.outputs.aem_username }}
-      AEM_PASSWORD: ${{ needs.fetch_staging_secrets.outputs.aem_password }}
-      AEM_AUTHOR_URL: ${{ needs.fetch_staging_secrets.outputs.aem_author_url }}
-      AEM_PUBLISH_URL: ${{ needs.fetch_staging_secrets.outputs.aem_publish_url }}
+      aws_secret_name: github-snowflake-labs-aem-staging-secrets
 
   upload_sidebar_json:
-    needs: [validate_and_stage_no_workato, fetch_staging_secrets]
+    needs: validate_and_stage_no_workato
     if: needs.validate_and_stage_no_workato.outputs.has_sidebar_changes == 'true'
     runs-on: ubuntu-latest
     environment:
       name: staging
-    env:
-      AEM_URL: ${{ needs.fetch_staging_secrets.outputs.aem_author_url }}
-      AEM_USERNAME: ${{ needs.fetch_staging_secrets.outputs.aem_username }}
-      AEM_PASSWORD: ${{ needs.fetch_staging_secrets.outputs.aem_password }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::886692307588:role/github-snowflake-labs-aem-iam-role
+          aws-region: us-west-1
+
+      - name: Fetch AEM staging secrets
+        run: |
+          secret=$(aws secretsmanager get-secret-value \
+            --secret-id github-snowflake-labs-aem-staging-secrets \
+            --query SecretString --output text)
+
+          aem_username=$(echo "$secret" | jq -r '.AEM_USERNAME')
+          aem_password=$(echo "$secret" | jq -r '.AEM_PASSWORD')
+          aem_author_url=$(echo "$secret" | jq -r '.AEM_AUTHOR_URL')
+
+          echo "::add-mask::$aem_username"
+          echo "::add-mask::$aem_password"
+
+          echo "AEM_URL=$aem_author_url" >> $GITHUB_ENV
+          echo "AEM_USERNAME=$aem_username" >> $GITHUB_ENV
+          echo "AEM_PASSWORD=$aem_password" >> $GITHUB_ENV
+
       - name: Checkout PR content (journeys)
         uses: actions/checkout@v4
         with:
@@ -801,7 +780,7 @@ jobs:
           echo "✅ Sidebar JSON upload complete"
 
   stage_journey_guides:
-    needs: [validate_and_stage_no_workato, fetch_staging_secrets]
+    needs: validate_and_stage_no_workato
     if: needs.validate_and_stage_no_workato.outputs.has_journey_guides == 'true'
     strategy:
       matrix:
@@ -816,8 +795,4 @@ jobs:
       base_sha: ${{ github.event.pull_request.base.sha }}
       pr_number: ${{ github.event.pull_request.number }}
       page_base_path: /content/snowflake-site/global/en/developers/guides/journey-sidebar-base
-    secrets:
-      AEM_USERNAME: ${{ needs.fetch_staging_secrets.outputs.aem_username }}
-      AEM_PASSWORD: ${{ needs.fetch_staging_secrets.outputs.aem_password }}
-      AEM_AUTHOR_URL: ${{ needs.fetch_staging_secrets.outputs.aem_author_url }}
-      AEM_PUBLISH_URL: ${{ needs.fetch_staging_secrets.outputs.aem_publish_url }}
+      aws_secret_name: github-snowflake-labs-aem-staging-secrets


### PR DESCRIPTION
GitHub Actions does not allow needs.*.outputs.* values to be passed as secrets: to reusable workflows — they evaluate to empty string. Fix by moving the AWS OIDC assume + Secrets Manager fetch directly into stage-to-aem.yml and publish-to-aem.yml via a new aws_secret_name input. Inline jobs (upload_sidebar_json) do their own fetch directly.

Removes the fetch_staging_secrets and fetch_prod_secrets jobs.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)