### PR TITLE
fix: add pull-requests: write permission to stage-to-aem job

### DIFF
--- a/.github/workflows/stage-to-aem.yml
+++ b/.github/workflows/stage-to-aem.yml
@@ -50,6 +50,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
     env:
       MAX_RETRIES: 3
       RETRY_DELAY: 5


### PR DESCRIPTION
Explicitly setting permissions removed inherited pull-requests: write, breaking the staging preview PR comment step.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)