### PR TITLE
Add Aditi to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # the repo. Unless a later match takes precedence,
 # these users will be requested for
 # review when someone opens a pull request.
-* @sfc-gh-kenguyen @sfc-gh-annafilippova @sfc-gh-ridasafdar @sfc-gh-stopchiy @sfc-gh-mnixon
+* @sfc-gh-kenguyen @sfc-gh-annafilippova @sfc-gh-ridasafdar @sfc-gh-stopchiy @sfc-gh-mnixon @sfc-gh-amadan
 
 
 # Content used in Northstar Workshops -- extra checks for in flight content


### PR DESCRIPTION
Aditi needs to be able to approve pull requests as the new maintainer of Guides