### PR TITLE
Fix: CoCo Desktop is GA, not Preview

### DIFF
--- a/site/sfguides/src/sfguide-build-end-to-end-ai-app-on-snowflake/sfguide-build-end-to-end-ai-app-on-snowflake.md
+++ b/site/sfguides/src/sfguide-build-end-to-end-ai-app-on-snowflake/sfguide-build-end-to-end-ai-app-on-snowflake.md
@@ -132,9 +132,7 @@ cortex --version
 
 ### Alternative: Snowflake CoCo Desktop
 
-If you prefer a visual IDE experience, [download CoCo Desktop](https://www.snowflake.com/en/product/limited-access/cortex-code/) instead of (or alongside) the CLI. It's a native Mac/Windows app with a file editor, integrated terminal, agentic browser, and the same AI capabilities.
-
-> **Note:** CoCo Desktop is currently a [Preview Feature](https://docs.snowflake.com/release-notes/preview-features) available to all accounts.
+If you prefer a visual IDE experience, [download CoCo Desktop](https://www.snowflake.com/en/product/limited-access/cortex-code/) instead of (or alongside) the CLI. It's a native Mac/Windows app with a file editor, integrated terminal, agentic browser, and the same AI capabilities. CoCo Desktop is Generally Available (GA) to all accounts.
 
 On first launch, follow the onboarding wizard:
 1. Click **Next** on the Welcome screen


### PR DESCRIPTION
CoCo Desktop is Generally Available — remove the outdated Preview Feature note from the HOL guide.

Built by [CoCo](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code) | Designed and Orchestrated by [Dash](https://www.linkedin.com/in/dash-desai/)