### PR TITLE
[SNOW-3835509] Add "Open in Snowflake" quickstart button to dbt Project developer guide

### DIFF
--- a/scripts/aem-staging/parse_markdown.py
+++ b/scripts/aem-staging/parse_markdown.py
@@ -194,7 +194,18 @@ def parse_markdown(
     if not fork_repo_link:
         fork_repo_link = f"https://github.com/Snowflake-Labs/sfquickstarts/tree/master/site/sfguides/src/{qid}"
     
-    open_in_snowflake_link = frontmatter.get('open_in_snowflake_link', '')
+    # Guide markdown uses spaced YAML keys (e.g. "open in snowflake link:").
+    # yaml.safe_load keeps those names as-is; it does not convert spaces to
+    # underscores. Looking up only open_in_snowflake_link returned '' and AEM
+    # never received quickstartArticleOpenInSnowflakeLink for first-time
+    # publishes after Workato was replaced. Accept all three spellings used
+    # in this repo.
+    open_in_snowflake_link = (
+        frontmatter.get('open_in_snowflake_link')
+        or frontmatter.get('open in snowflake link')
+        or frontmatter.get('open in snowflake')
+        or ''
+    )
     
     tags = frontmatter.get('tags', [])
     if isinstance(tags, list):

--- a/site/sfguides/src/dbt-projects-on-snowflake/dbt-projects-on-snowflake.md
+++ b/site/sfguides/src/dbt-projects-on-snowflake/dbt-projects-on-snowflake.md
@@ -7,6 +7,7 @@ environments: web
 status: Published 
 feedback link: https://github.com/Snowflake-Labs/sfguides/issues
 fork repo link: https://github.com/Snowflake-Labs/getting-started-with-dbt-on-snowflake
+open in snowflake link: https://app.snowflake.com/templates?template=getting_started_with_dbt_projects&utm_source=snowflake-devrel&utm_medium=developer-guides&utm_content=dbt-projects-on-snowflake&utm_cta=developer-guides-deeplink
 
 # Exploring dbt Projects on Snowflake
 ## Overview 


### PR DESCRIPTION
SNOW-3835509

## Summary
Adds the sticky **Ready to get started?** / **OPEN IN SNOWFLAKE** CTA on the [dbt Projects on Snowflake](https://www.snowflake.com/en/developers/guides/dbt-projects-on-snowflake/) developer guide.
The widget is rendered by AEM when the content fragment field `quickstartArticleOpenInSnowflakeLink` is set. This PR supplies that URL from guide frontmatter (same pattern as Iceberg / Dynamic Tables) and fixes the Python AEM parser so the URL is actually published.

## Changes
`site/sfguides/src/dbt-projects-on-snowflake/dbt-projects-on-snowflake.md`
Adds the `open in snowflake link` frontmatter field.

`scripts/aem-staging/parse_markdown.py`
The parser previously only looked up `open_in_snowflake_link` (underscores). Guide markdown uses spaced YAML keys (`open in snowflake link:`); `yaml.safe_load` keeps those names as-is, so the lookup returned empty and AEM never received the field for new CTAs after Workato was replaced.
The parser now accepts all three spellings used in this repo: `open_in_snowflake_link`, `open in snowflake link`, and `open in snowflake`.
Visuals (navy pill, bottom-right placement) live in the AEM guide template, not this repo.

**Test plan**

Temp link for verification: https://www.snowflake.com/en/developers/guides/dbt-projects-on-snowflake/?v=90

<img width="3420" height="1818" alt="image" src="https://github.com/user-attachments/assets/587df103-8d7e-47bb-922f-46141cf090b5" />
